### PR TITLE
[oap-native-sql] Allow to force to use shuffledHashJoin

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -334,6 +334,13 @@ object SQLConf {
     .booleanConf
     .createWithDefault(true)
 
+  val FORCE_HASHJOIN = buildConf("spark.sql.join.forceHashJoin")
+    .internal()
+    .doc("When true, force to use shuffle hash join.")
+    .version("2.0.0")
+    .booleanConf
+    .createWithDefault(false)
+
   val RADIX_SORT_ENABLED = buildConf("spark.sql.sort.enableRadixSort")
     .internal()
     .doc("When true, enable use of radix sort when possible. Radix sort is much faster but " +
@@ -2886,6 +2893,8 @@ class SQLConf extends Serializable with Logging {
     getConf(ADVANCED_PARTITION_PREDICATE_PUSHDOWN)
 
   def preferSortMergeJoin: Boolean = getConf(PREFER_SORTMERGEJOIN)
+
+  def forceHashJoin: Boolean = getConf(FORCE_HASHJOIN)
 
   def enableRadixSort: Boolean = getConf(RADIX_SORT_ENABLED)
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -297,6 +297,13 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             canBroadcast(left) && !hint.leftHint.exists(_.strategy.contains(NO_BROADCAST_HASH)),
             canBroadcast(right) && !hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_HASH)))
             .orElse {
+              if (conf.forceHashJoin) {
+                createShuffleHashJoin(true, true)
+              } else {
+                None
+              }
+            }
+            .orElse {
               if (!conf.preferSortMergeJoin) {
                 createShuffleHashJoin(
                   canBuildLocalHashMap(left) && muchSmaller(left, right),


### PR DESCRIPTION
This patch adds a new option `spark.sql.join.forceHashJoin` which allows to use SHJ over SMJ when setting to true. 

Signed-off-by: Chendi Xue <chendi.xue@intel.com>
Signed-off-by: Yuan Zhou <yuan.zhou@intel.com>

