### PR TITLE
Shuffle I/O plugin read path support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -234,6 +234,10 @@
       <artifactId>scala-xml_${scala.binary.version}</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.scala-lang.modules</groupId>
+      <artifactId>scala-java8-compat_${scala.binary.version}</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
     </dependency>

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleDriverComponents.java
@@ -18,8 +18,10 @@
 package org.apache.spark.shuffle.api;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.apache.spark.annotation.Private;
+import org.apache.spark.shuffle.api.metadata.ShuffleOutputTracker;
 
 /**
  * :: Private ::
@@ -47,18 +49,7 @@ public interface ShuffleDriverComponents {
    */
   void cleanupApplication();
 
-  /**
-   * Called once per shuffle id when the shuffle id is first generated for a shuffle stage.
-   *
-   * @param shuffleId The unique identifier for the shuffle stage.
-   */
-  default void registerShuffle(int shuffleId) {}
-
-  /**
-   * Removes shuffle data associated with the given shuffle.
-   *
-   * @param shuffleId The unique identifier for the shuffle stage.
-   * @param blocking Whether this call should block on the deletion of the data.
-   */
-  default void removeShuffle(int shuffleId, boolean blocking) {}
+  default Optional<ShuffleOutputTracker> shuffleOutputTracker() {
+    return Optional.empty();
+  }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleExecutorComponents.java
@@ -26,6 +26,7 @@ import org.apache.spark.annotation.Private;
 import org.apache.spark.shuffle.api.io.ShuffleBlockInputStream;
 import org.apache.spark.shuffle.api.metadata.ShuffleBlockInfo;
 import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleUpdater;
 
 /**
  * :: Private ::
@@ -44,8 +45,15 @@ public interface ShuffleExecutorComponents {
    * @param execId The unique identifier of the executor being initialized
    * @param extraConfigs Extra configs that were returned by
    *                     {@link ShuffleDriverComponents#initializeApplication()}
+   * @param updater A hook to the driver to send dynamic updates to shuffle storage information.
+   *                Only provided if {@link ShuffleDriverComponents#shuffleOutputTracker()} returns
+   *                a non-empty value (e.g. shuffle output tracking is enabled).
    */
-  void initializeExecutor(String appId, String execId, Map<String, String> extraConfigs);
+  void initializeExecutor(
+      String appId,
+      String execId,
+      Map<String, String> extraConfigs,
+      Optional<ShuffleUpdater> updater);
 
   /**
    * Called once per map task to create a writer that will be responsible for persisting all the

--- a/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/ShuffleMapOutputWriter.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.api;
 import java.io.IOException;
 
 import org.apache.spark.annotation.Private;
+import org.apache.spark.shuffle.api.metadata.MapOutputCommitMessage;
 
 /**
  * :: Private ::
@@ -63,7 +64,7 @@ public interface ShuffleMapOutputWriter {
    * The returned array should contain, for each partition from (0) to (numPartitions - 1), the
    * number of bytes written by the partition writer for that partition id.
    */
-  long[] commitAllPartitions() throws IOException;
+  MapOutputCommitMessage commitAllPartitions() throws IOException;
 
   /**
    * Abort all of the writes done by any writers returned by {@link #getPartitionWriter(int)}.

--- a/core/src/main/java/org/apache/spark/shuffle/api/io/ShuffleBlockInputStream.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/io/ShuffleBlockInputStream.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.io;
+
+import java.io.FilterInputStream;
+import java.io.InputStream;
+import java.util.Optional;
+
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata;
+
+public class ShuffleBlockInputStream extends FilterInputStream {
+
+  private final Optional<ShuffleBlockMetadata> blockMetadata;
+
+  private ShuffleBlockInputStream(
+      InputStream in, Optional<ShuffleBlockMetadata> blockMetadata) {
+    super(in);
+    this.blockMetadata = blockMetadata;
+  }
+
+  public static ShuffleBlockInputStream of(InputStream in) {
+    return new ShuffleBlockInputStream(in, Optional.empty());
+  }
+
+  public static ShuffleBlockInputStream of(InputStream in, ShuffleBlockMetadata blockMetadata) {
+    return new ShuffleBlockInputStream(in, Optional.of(blockMetadata));
+  }
+
+  public Optional<ShuffleBlockMetadata> getBlockMetadata() {
+    return blockMetadata;
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+import java.util.Optional;
+
+import org.apache.spark.annotation.Private;
+
+/**
+ * :: Private ::
+ *
+ * Represents the result of writing map outputs for a shuffle map task.
+ * <p>
+ * Partition lengths represents the length of each block written in the map task. This can
+ * be used for downstream readers to allocate resources, such as in-memory buffers.
+ * <p>
+ * Map output writers can choose to attach arbitrary metadata tags to register with a
+ * shuffle output tracker (a module that is currently yet to be built in a future
+ * iteration of the shuffle storage APIs).
+ */
+@Private
+public final class MapOutputCommitMessage {
+
+  private final long[] partitionLengths;
+  private final Optional<MapOutputMetadata> mapOutputMetadata;
+
+  MapOutputCommitMessage(
+      long[] partitionLengths, Optional<MapOutputMetadata> mapOutputMetadata) {
+    this.partitionLengths = partitionLengths;
+    this.mapOutputMetadata = mapOutputMetadata;
+  }
+
+  public static MapOutputCommitMessage of(long[] partitionLengths) {
+    return new MapOutputCommitMessage(partitionLengths, Optional.empty());
+  }
+
+  public static MapOutputCommitMessage of(long[] partitionLengths, MapOutputMetadata mapOutputMetadata) {
+    return new MapOutputCommitMessage(partitionLengths, Optional.of(mapOutputMetadata));
+  }
+
+  public long[] getPartitionLengths() {
+    return partitionLengths;
+  }
+
+  public Optional<MapOutputMetadata> getMapOutputMetadata() {
+    return mapOutputMetadata;
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
@@ -49,7 +49,8 @@ public final class MapOutputCommitMessage {
     return new MapOutputCommitMessage(partitionLengths, Optional.empty());
   }
 
-  public static MapOutputCommitMessage of(long[] partitionLengths, MapOutputMetadata mapOutputMetadata) {
+  public static MapOutputCommitMessage of(
+      long[] partitionLengths, MapOutputMetadata mapOutputMetadata) {
     return new MapOutputCommitMessage(partitionLengths, Optional.of(mapOutputMetadata));
   }
 

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputCommitMessage.java
@@ -39,7 +39,7 @@ public final class MapOutputCommitMessage {
   private final long[] partitionLengths;
   private final Optional<MapOutputMetadata> mapOutputMetadata;
 
-  MapOutputCommitMessage(
+  public MapOutputCommitMessage(
       long[] partitionLengths, Optional<MapOutputMetadata> mapOutputMetadata) {
     this.partitionLengths = partitionLengths;
     this.mapOutputMetadata = mapOutputMetadata;

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/MapOutputMetadata.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+import java.io.Serializable;
+
+/**
+ * :: Private ::
+ *
+ * An opaque metadata tag for registering the result of committing the output of a
+ * shuffle map task.
+ * <p>
+ * All implementations must be serializable since this is sent from the executors to
+ * the driver.
+ */
+public interface MapOutputMetadata extends Serializable {}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockInfo.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockInfo.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+import org.apache.spark.storage.BlockManagerId;
+
+public class ShuffleBlockInfo {
+  private final int shuffleId;
+  private final int mapIndex;
+  private final int reduceId;
+  private final long blockLength;
+  private final long mapTaskAttemptId;
+  private final BlockManagerId shuffleLocation;
+
+  public ShuffleBlockInfo(
+      int shuffleId,
+      int mapIndex,
+      int reduceId,
+      long blockLength,
+      long mapTaskAttemptId,
+      BlockManagerId mapperLocation) {
+    this.shuffleId = shuffleId;
+    this.mapIndex = mapIndex;
+    this.reduceId = reduceId;
+    this.blockLength = blockLength;
+    this.mapTaskAttemptId = mapTaskAttemptId;
+    this.shuffleLocation = mapperLocation;
+  }
+
+  public int getShuffleId() {
+    return shuffleId;
+  }
+
+  public int getMapIndex() {
+    return mapIndex;
+  }
+
+  public int getReduceId() {
+    return reduceId;
+  }
+
+  public long getBlockLength() {
+    return blockLength;
+  }
+
+  public long getMapTaskAttemptId() {
+    return mapTaskAttemptId;
+  }
+
+  public BlockManagerId getShuffleLocation() {
+    return shuffleLocation;
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockMetadata.java
@@ -17,8 +17,17 @@
 
 package org.apache.spark.shuffle.api.metadata;
 
+import java.io.Serializable;
+
 /**
  * Metadata tags returned from partition readers for each input stream to be read by
  * the reduce task.
  */
-public interface ShuffleBlockMetadata {}
+public interface ShuffleBlockMetadata extends Serializable {
+
+  /**
+   * Used for display in fetch failed exceptions.
+   */
+  String toPrintableString();
+
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleBlockMetadata.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+/**
+ * Metadata tags returned from partition readers for each input stream to be read by
+ * the reduce task.
+ */
+public interface ShuffleBlockMetadata {}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleMetadata.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+import java.io.Serializable;
+
+/**
+ * :: Private ::
+ *
+ * An opaque metadata tag passed to shuffle reduce tasks to aid in reading shuffle blocks.
+ * <p>
+ * All implementations must be serializable since this is sent from the driver to the executors.
+ */
+public interface ShuffleMetadata extends Serializable {}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -17,6 +17,8 @@
 
 package org.apache.spark.shuffle.api.metadata;
 
+import java.util.Optional;
+
 /**
  * :: Private ::
  *
@@ -53,4 +55,13 @@ public interface ShuffleOutputTracker {
    * shuffles.
    */
   void removeMapOutput(int shuffleId, int mapId, long mapTaskAttemptId);
+
+  /**
+   * Called when a shuffle reduce stage starts, and shuffle readers thus need extra metadata
+   * to read shuffle blocks.
+   * <p>
+   * Implementations can return an empty value if no shuffle metadata is available for the given
+   * shuffle id.
+   */
+  Optional<ShuffleMetadata> getShuffleMetadata(int shuffleId);
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -102,6 +102,12 @@ public interface ShuffleOutputTracker {
    * executor are checked against this method. For each map output that is not stored externally,
    * that map output has to be recomputed.
    */
-  boolean isMapOutputAvailableExternally(
-      int shuffleId, int mapId, long mapTaskAttemptId);
+  boolean isMapOutputAvailableExternally(int shuffleId, int mapId, long mapTaskAttemptId);
+
+  /**
+   * Send an update to this shuffle output tracker.
+   * <p>
+   * Executors can call
+   */
+  default void updateShuffleOutput(ShuffleOutputUpdate update) {}
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -46,7 +46,7 @@ public interface ShuffleOutputTracker {
    * persisted by this shuffle output tracker.
    */
   void registerMapOutput(
-      int shuffleId, int mapId, long mapTaskAttemptId, MapOutputMetadata mapOutputMetadata);
+      int shuffleId, int mapIndex, long mapId, MapOutputMetadata mapOutputMetadata);
 
   /**
    * Called when the given map output is discarded, and will not longer be used in future Spark

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+/**
+ * :: Private ::
+ *
+ * A plugin that can monitor the storage of shuffle data from map tasks, and can provide
+ * metadata to shuffle readers to aid their reading of shuffle blocks in reduce tasks.
+ * <p>
+ * {@link MapOutputMetadata} instances provided from the plugin tree's implementation of
+ * {@link org.apache.spark.shuffle.api.ShuffleMapOutputWriter} are sent to
+ * <p>
+ * Implementations MUST be thread-safe. Spark will invoke methods in this module in parallel.
+ */
+public interface ShuffleOutputTracker {
+
+  /**
+   * Called when a new shuffle stage is going to be run.
+   */
+  void registerShuffle(int shuffleId);
+
+  /**
+   * Called when the shuffle with the given id is unregistered because it will no longer
+   * be used by Spark tasks.
+   */
+  void unregisterShuffle(int shuffleId, boolean blocking);
+
+  /**
+   * Called when a map task completes, and the map output writer has provided metadata to be
+   * persisted by this shuffle output tracker.
+   */
+  void registerMapOutput(
+      int shuffleId, int mapId, long mapTaskAttemptId, MapOutputMetadata mapOutputMetadata);
+
+  /**
+   * Called when the given map output is discarded, and will not longer be used in future Spark
+   * shuffles.
+   */
+  void removeMapOutput(int shuffleId, int mapId, long mapTaskAttemptId);
+}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputTracker.java
@@ -64,4 +64,44 @@ public interface ShuffleOutputTracker {
    * shuffle id.
    */
   Optional<ShuffleMetadata> getShuffleMetadata(int shuffleId);
+
+  /**
+   * Called when a shuffle reader implementation throws a fetch failure exception for the given
+   * shuffle block.
+   * <p>
+   * Implementations can choose to update internal state accordingly.
+   */
+  default void handleFetchFailure(
+      int shuffleId,
+      int mapId,
+      int reduceId,
+      long mapTaskAttemptId,
+      Optional<ShuffleBlockMetadata> blockMetadata) {}
+
+  /**
+   * Called when an executor is lost.
+   * <p>
+   * Shuffle plugin implementations that store any state on the lost executor should update
+   * internal state accordingly.
+   */
+  default void handleExecutorLost(String executorId) {}
+
+  /**
+   * Called when a host running one or more executors is lost.
+   * <p>
+   * Shuffle plugin implementations that store any state on the lost host should update
+   * internal state accordingly.
+   */
+  default void handleHostLost(String host) {}
+
+  /**
+   * Inspect whether or not all partitions from the given map output are available in an external
+   * system, i.e. offloaded from an executor.
+   * <p>
+   * If the executor that ran the map task is lost, all map outputs that were written by that
+   * executor are checked against this method. For each map output that is not stored externally,
+   * that map output has to be recomputed.
+   */
+  boolean isMapOutputAvailableExternally(
+      int shuffleId, int mapId, long mapTaskAttemptId);
 }

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputUpdate.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleOutputUpdate.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+import java.io.Serializable;
+
+/**
+ * Represents an opaque message to dynamically update information about the storage of shuffle
+ * data.
+ * <p>
+ * Executors are expected to send appropriate implementations of these to the driver via
+ * {@link ShuffleUpdater#updateShuffleOutput(ShuffleOutputUpdate)}, and the driver receives
+ * these updates in {@link ShuffleOutputTracker#updateShuffleOutput(ShuffleOutputUpdate)}.
+ */
+public interface ShuffleOutputUpdate extends Serializable {}

--- a/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleUpdater.java
+++ b/core/src/main/java/org/apache/spark/shuffle/api/metadata/ShuffleUpdater.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.api.metadata;
+
+/**
+ * Passed to {@link org.apache.spark.shuffle.api.ShuffleExecutorComponents} to allow for executors
+ * implementing the shuffle plugin tree to dynamically update shuffle storage metadata, sending
+ * appropriate updates to the driver.
+ */
+public interface ShuffleUpdater {
+
+  /**
+   * Sends an opaque update message to the driver.
+   * <p>
+   * This eventually delegates to
+   * {@link ShuffleOutputTracker#updateShuffleOutput(ShuffleOutputUpdate)} on the driver.
+   */
+  void updateShuffleOutput(ShuffleOutputUpdate update);
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriter.java
@@ -130,7 +130,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
         .createMapOutputWriter(shuffleId, mapId, numPartitions);
     try {
       if (!records.hasNext()) {
-        partitionLengths = mapOutputWriter.commitAllPartitions();
+        partitionLengths = mapOutputWriter.commitAllPartitions().getPartitionLengths();
         mapStatus = MapStatus$.MODULE$.apply(
           blockManager.shuffleServerId(), partitionLengths, mapId);
         return;
@@ -219,7 +219,7 @@ final class BypassMergeSortShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       }
       partitionWriters = null;
     }
-    return mapOutputWriter.commitAllPartitions();
+    return mapOutputWriter.commitAllPartitions().getPartitionLengths();
   }
 
   private void writePartitionedDataWithChannel(

--- a/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriter.java
@@ -266,7 +266,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
     if (spills.length == 0) {
       final ShuffleMapOutputWriter mapWriter = shuffleExecutorComponents
           .createMapOutputWriter(shuffleId, mapId, partitioner.numPartitions());
-      return mapWriter.commitAllPartitions();
+      return mapWriter.commitAllPartitions().getPartitionLengths();
     } else if (spills.length == 1) {
       Optional<SingleSpillShuffleMapOutputWriter> maybeSingleFileWriter =
           shuffleExecutorComponents.createSingleFileMapOutputWriter(shuffleId, mapId);
@@ -327,7 +327,7 @@ public class UnsafeShuffleWriter<K, V> extends ShuffleWriter<K, V> {
       // to be counted as shuffle write, but this will lead to double-counting of the final
       // SpillInfo's bytes.
       writeMetrics.decBytesWritten(spills[spills.length - 1].file.length());
-      partitionLengths = mapWriter.commitAllPartitions();
+      partitionLengths = mapWriter.commitAllPartitions().getPartitionLengths();
     } catch (Exception e) {
       try {
         mapWriter.abort(e);

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleBlockMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleBlockMetadata.java
@@ -31,4 +31,9 @@ public class LocalDiskShuffleBlockMetadata implements ShuffleBlockMetadata {
   public BlockId getBlockId() {
     return blockId;
   }
+
+  @Override
+  public String toPrintableString() {
+    return blockId.toString();
+  }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleBlockMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleBlockMetadata.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort.io;
+
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata;
+import org.apache.spark.storage.BlockId;
+
+public class LocalDiskShuffleBlockMetadata implements ShuffleBlockMetadata {
+
+  private final BlockId blockId;
+
+  public LocalDiskShuffleBlockMetadata(BlockId blockId) {
+    this.blockId = blockId;
+  }
+
+  public BlockId getBlockId() {
+    return blockId;
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleExecutorComponents.java
@@ -36,6 +36,7 @@ import org.apache.spark.shuffle.api.SingleSpillShuffleMapOutputWriter;
 import org.apache.spark.shuffle.api.io.ShuffleBlockInputStream;
 import org.apache.spark.shuffle.api.metadata.ShuffleBlockInfo;
 import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleUpdater;
 import org.apache.spark.shuffle.sort.SortShuffleManager$;
 import org.apache.spark.storage.BlockManager;
 
@@ -63,7 +64,11 @@ public class LocalDiskShuffleExecutorComponents implements ShuffleExecutorCompon
   }
 
   @Override
-  public void initializeExecutor(String appId, String execId, Map<String, String> extraConfigs) {
+  public void initializeExecutor(
+      String appId,
+      String execId,
+      Map<String, String> extraConfigs,
+      Optional<ShuffleUpdater> updater) {
     blockManager = SparkEnv.get().blockManager();
     if (blockManager == null) {
       throw new IllegalStateException("No blockManager available from the SparkEnv.");

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriter.java
@@ -35,6 +35,7 @@ import org.apache.spark.shuffle.api.ShufflePartitionWriter;
 import org.apache.spark.shuffle.api.WritableByteChannelWrapper;
 import org.apache.spark.internal.config.package$;
 import org.apache.spark.shuffle.IndexShuffleBlockResolver;
+import org.apache.spark.shuffle.api.metadata.MapOutputCommitMessage;
 import org.apache.spark.util.Utils;
 
 /**
@@ -97,7 +98,7 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
   }
 
   @Override
-  public long[] commitAllPartitions() throws IOException {
+  public MapOutputCommitMessage commitAllPartitions() throws IOException {
     // Check the position after transferTo loop to see if it is in the right position and raise a
     // exception if it is incorrect. The position will not be increased to the expected length
     // after calling transferTo in kernel version 2.6.32. This issue is described at
@@ -113,7 +114,7 @@ public class LocalDiskShuffleMapOutputWriter implements ShuffleMapOutputWriter {
     cleanUp();
     File resolvedTmp = outputTempFile != null && outputTempFile.isFile() ? outputTempFile : null;
     blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, resolvedTmp);
-    return partitionLengths;
+    return MapOutputCommitMessage.of(partitionLengths);
   }
 
   @Override

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMetadata.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMetadata.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.sort.io;
+
+import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
+
+public class LocalDiskShuffleMetadata implements ShuffleMetadata {
+  private final boolean serializerSupportsObjectRelocation;
+
+  public LocalDiskShuffleMetadata(boolean serializerSupportsObjectRelocation) {
+    this.serializerSupportsObjectRelocation = serializerSupportsObjectRelocation;
+  }
+
+  public boolean doesSerializerSupportObjectRelocation() {
+    return serializerSupportsObjectRelocation;
+  }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
@@ -20,6 +20,7 @@ package org.apache.spark.shuffle.sort.io;
 import java.util.Optional;
 
 import org.apache.spark.shuffle.api.metadata.MapOutputMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata;
 import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
 import org.apache.spark.shuffle.api.metadata.ShuffleOutputTracker;
 import org.apache.spark.storage.BlockManagerMaster;
@@ -51,5 +52,10 @@ public final class LocalDiskShuffleOutputTracker implements ShuffleOutputTracker
   @Override
   public Optional<ShuffleMetadata> getShuffleMetadata(int shuffleId) {
     return Optional.empty();
+  }
+
+  @Override
+  public boolean isMapOutputAvailableExternally(int shuffleId, int mapId, long mapTaskAttemptId) {
+    return false;
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
@@ -40,7 +40,7 @@ public final class LocalDiskShuffleOutputTracker implements ShuffleOutputTracker
 
   @Override
   public void registerMapOutput(
-      int shuffleId, int mapId, long mapTaskAttemptId, MapOutputMetadata mapOutputMetadata) {
+      int shuffleId, int mapIndex, long mapId, MapOutputMetadata mapOutputMetadata) {
   }
 
   @Override

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
@@ -17,36 +17,34 @@
 
 package org.apache.spark.shuffle.sort.io;
 
-import java.util.Collections;
-import java.util.Map;
-import java.util.Optional;
-
-import org.apache.spark.SparkEnv;
-import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.shuffle.api.metadata.MapOutputMetadata;
 import org.apache.spark.shuffle.api.metadata.ShuffleOutputTracker;
 import org.apache.spark.storage.BlockManagerMaster;
 
-public class LocalDiskShuffleDriverComponents implements ShuffleDriverComponents {
+public final class LocalDiskShuffleOutputTracker implements ShuffleOutputTracker {
 
-  private LocalDiskShuffleOutputTracker outputTracker;
+  private final BlockManagerMaster blockManagerMaster;
 
-  @Override
-  public Map<String, String> initializeApplication() {
-    BlockManagerMaster blockManagerMaster = SparkEnv.get().blockManager().master();
-    outputTracker = new LocalDiskShuffleOutputTracker(blockManagerMaster);
-    return Collections.emptyMap();
+  public LocalDiskShuffleOutputTracker(BlockManagerMaster blockManagerMaster) {
+    this.blockManagerMaster = blockManagerMaster;
   }
 
   @Override
-  public void cleanupApplication() {
-    // nothing to clean up
+  public void registerShuffle(int shuffleId) {
   }
 
   @Override
-  public Optional<ShuffleOutputTracker> shuffleOutputTracker() {
-    if (outputTracker == null) {
-      throw new IllegalStateException("Driver components must be initialized before use");
-    }
-    return Optional.of(outputTracker);
+  public void unregisterShuffle(int shuffleId, boolean blocking) {
+    blockManagerMaster.removeShuffle(shuffleId, blocking);
+  }
+
+  @Override
+  public void registerMapOutput(
+      int shuffleId, int mapId, long mapTaskAttemptId, MapOutputMetadata mapOutputMetadata) {
+  }
+
+  @Override
+  public void removeMapOutput(int shuffleId, int mapId, long mapTaskAttemptId) {
+
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskShuffleOutputTracker.java
@@ -17,7 +17,10 @@
 
 package org.apache.spark.shuffle.sort.io;
 
+import java.util.Optional;
+
 import org.apache.spark.shuffle.api.metadata.MapOutputMetadata;
+import org.apache.spark.shuffle.api.metadata.ShuffleMetadata;
 import org.apache.spark.shuffle.api.metadata.ShuffleOutputTracker;
 import org.apache.spark.storage.BlockManagerMaster;
 
@@ -30,8 +33,7 @@ public final class LocalDiskShuffleOutputTracker implements ShuffleOutputTracker
   }
 
   @Override
-  public void registerShuffle(int shuffleId) {
-  }
+  public void registerShuffle(int shuffleId) {}
 
   @Override
   public void unregisterShuffle(int shuffleId, boolean blocking) {
@@ -44,7 +46,10 @@ public final class LocalDiskShuffleOutputTracker implements ShuffleOutputTracker
   }
 
   @Override
-  public void removeMapOutput(int shuffleId, int mapId, long mapTaskAttemptId) {
+  public void removeMapOutput(int shuffleId, int mapId, long mapTaskAttemptId) {}
 
+  @Override
+  public Optional<ShuffleMetadata> getShuffleMetadata(int shuffleId) {
+    return Optional.empty();
   }
 }

--- a/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskSingleSpillMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/sort/io/LocalDiskSingleSpillMapOutputWriter.java
@@ -20,9 +20,11 @@ package org.apache.spark.shuffle.sort.io;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Optional;
 
 import org.apache.spark.shuffle.IndexShuffleBlockResolver;
 import org.apache.spark.shuffle.api.SingleSpillShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.metadata.MapOutputMetadata;
 import org.apache.spark.util.Utils;
 
 public class LocalDiskSingleSpillMapOutputWriter
@@ -42,14 +44,14 @@ public class LocalDiskSingleSpillMapOutputWriter
   }
 
   @Override
-  public void transferMapSpillFile(
-      File mapSpillFile,
-      long[] partitionLengths) throws IOException {
+  public Optional<MapOutputMetadata> transferMapSpillFile(
+      File mapSpillFile, long[] partitionLengths) throws IOException {
     // The map spill file already has the proper format, and it contains all of the partition data.
     // So just transfer it directly to the destination without any merging.
     File outputFile = blockResolver.getDataFile(shuffleId, mapId);
     File tempFile = Utils.tempFileWith(outputFile);
     Files.move(mapSpillFile.toPath(), tempFile.toPath());
     blockResolver.writeIndexFileAndCommit(shuffleId, mapId, partitionLengths, tempFile);
+    return Optional.empty();
   }
 }

--- a/core/src/main/scala/org/apache/spark/BlocksToFetch.scala
+++ b/core/src/main/scala/org/apache/spark/BlocksToFetch.scala
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.BlocksToFetch.BlocksByExecutorId
+import org.apache.spark.shuffle.api.metadata.ShuffleMetadata
+import org.apache.spark.storage.{BlockId, BlockManagerId}
+
+private[spark] case class BlocksToFetch(
+  blocks: BlocksByExecutorId, metadata: Option[ShuffleMetadata])
+
+private object BlocksToFetch {
+  type BlocksByExecutorId = Iterable[(BlockManagerId, Seq[(BlockId, Long, Int)])]
+}

--- a/core/src/main/scala/org/apache/spark/ContextCleaner.scala
+++ b/core/src/main/scala/org/apache/spark/ContextCleaner.scala
@@ -59,9 +59,7 @@ private class CleanupTaskWeakReference(
  * to be processed when the associated object goes out of scope of the application. Actual
  * cleanup is performed in a separate daemon thread.
  */
-private[spark] class ContextCleaner(
-    sc: SparkContext,
-    shuffleDriverComponents: ShuffleDriverComponents) extends Logging {
+private[spark] class ContextCleaner(sc: SparkContext) extends Logging {
 
   /**
    * A buffer to ensure that `CleanupTaskWeakReference`s are not garbage collected as long as they
@@ -223,8 +221,7 @@ private[spark] class ContextCleaner(
   def doCleanupShuffle(shuffleId: Int, blocking: Boolean): Unit = {
     try {
       logDebug("Cleaning shuffle " + shuffleId)
-      mapOutputTrackerMaster.unregisterShuffle(shuffleId)
-      shuffleDriverComponents.removeShuffle(shuffleId, blocking)
+      mapOutputTrackerMaster.unregisterShuffle(shuffleId, blocking)
       listeners.asScala.foreach(_.shuffleCleaned(shuffleId))
       logDebug("Cleaned shuffle " + shuffleId)
     } catch {

--- a/core/src/main/scala/org/apache/spark/Dependency.scala
+++ b/core/src/main/scala/org/apache/spark/Dependency.scala
@@ -96,7 +96,6 @@ class ShuffleDependency[K: ClassTag, V: ClassTag, C: ClassTag](
     shuffleId, this)
 
   _rdd.sparkContext.cleaner.foreach(_.registerShuffleForCleanup(this))
-  _rdd.sparkContext.shuffleDriverComponents.registerShuffle(shuffleId)
 }
 
 

--- a/core/src/main/scala/org/apache/spark/SerializedShuffleInfo.scala
+++ b/core/src/main/scala/org/apache/spark/SerializedShuffleInfo.scala
@@ -1,0 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+private[spark] case class SerializedShuffleInfo(
+  serializedMapStatuses: Array[Byte], serializedShuffleMetadata: Array[Byte])

--- a/core/src/main/scala/org/apache/spark/ShuffleInfo.scala
+++ b/core/src/main/scala/org/apache/spark/ShuffleInfo.scala
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.shuffle.api.metadata.ShuffleMetadata
+
+private[spark] case class ShuffleInfo(
+    mapStatuses: Array[MapStatus], shuffleMetadata: Option[ShuffleMetadata])

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -516,10 +516,12 @@ class SparkContext(config: SparkConf) extends Logging {
     _shuffleDriverComponents.initializeApplication().asScala.foreach { case (k, v) =>
       _conf.set(ShuffleDataIOUtils.SHUFFLE_SPARK_CONF_PREFIX + k, v)
     }
+    val shuffleOutputTracker = _shuffleDriverComponents.shuffleOutputTracker().asScala
     // Should really be done in SparkEnv creation, but initialization ordering is quite
     // difficult...
     env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].setShuffleOutputTracker(
-      _shuffleDriverComponents.shuffleOutputTracker().asScala)
+      shuffleOutputTracker)
+    _conf.set(SHUFFLE_IO_PLUGIN_OUTPUT_TRACKING_ENABLED, shuffleOutputTracker.isDefined)
 
     // We need to register "HeartbeatReceiver" before "createTaskScheduler" because Executor will
     // retrieve "HeartbeatReceiver" in the constructor. (SPARK-6640)

--- a/core/src/main/scala/org/apache/spark/SparkContext.scala
+++ b/core/src/main/scala/org/apache/spark/SparkContext.scala
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.{AtomicBoolean, AtomicInteger, AtomicReferenc
 import scala.collection.JavaConverters._
 import scala.collection.Map
 import scala.collection.mutable.HashMap
+import scala.compat.java8.OptionConverters._
 import scala.language.implicitConversions
 import scala.reflect.{classTag, ClassTag}
 import scala.util.control.NonFatal
@@ -515,6 +516,10 @@ class SparkContext(config: SparkConf) extends Logging {
     _shuffleDriverComponents.initializeApplication().asScala.foreach { case (k, v) =>
       _conf.set(ShuffleDataIOUtils.SHUFFLE_SPARK_CONF_PREFIX + k, v)
     }
+    // Should really be done in SparkEnv creation, but initialization ordering is quite
+    // difficult...
+    env.mapOutputTracker.asInstanceOf[MapOutputTrackerMaster].setShuffleOutputTracker(
+      _shuffleDriverComponents.shuffleOutputTracker().asScala)
 
     // We need to register "HeartbeatReceiver" before "createTaskScheduler" because Executor will
     // retrieve "HeartbeatReceiver" in the constructor. (SPARK-6640)
@@ -578,7 +583,7 @@ class SparkContext(config: SparkConf) extends Logging {
 
     _cleaner =
       if (_conf.get(CLEANER_REFERENCE_TRACKING)) {
-        Some(new ContextCleaner(this, _shuffleDriverComponents))
+        Some(new ContextCleaner(this))
       } else {
         None
       }

--- a/core/src/main/scala/org/apache/spark/TaskEndReason.scala
+++ b/core/src/main/scala/org/apache/spark/TaskEndReason.scala
@@ -22,6 +22,7 @@ import java.io.{ObjectInputStream, ObjectOutputStream}
 import org.apache.spark.annotation.DeveloperApi
 import org.apache.spark.internal.Logging
 import org.apache.spark.scheduler.AccumulableInfo
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.{AccumulatorV2, Utils}
 
@@ -86,7 +87,8 @@ case class FetchFailed(
     mapId: Long,
     mapIndex: Int,
     reduceId: Int,
-    message: String)
+    message: String,
+    blockMetadata: Option[ShuffleBlockMetadata] = None)
   extends TaskFailedReason {
   override def toErrorString: String = {
     val bmAddressString = if (bmAddress == null) "null" else bmAddress.toString

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -1096,6 +1096,15 @@ package object config {
       .stringConf
       .createWithDefault(classOf[LocalDiskShuffleDataIO].getName)
 
+  private[spark] val SHUFFLE_IO_PLUGIN_OUTPUT_TRACKING_ENABLED =
+    ConfigBuilder("spark.shuffle.sort.io.plugin.output.tracking.enabled")
+      .doc("Indicates whether or not the shuffle plugin has enabled custom output tracking." +
+        "Determined by the driver and sent to the executors; users should not set this manually.")
+      .version("3.1.0")
+      .internal()
+      .booleanConf
+      .createWithDefault(false)
+
   private[spark] val SHUFFLE_FILE_BUFFER_SIZE =
     ConfigBuilder("spark.shuffle.file.buffer")
       .doc("Size of the in-memory buffer for each shuffle file output stream, in KiB unless " +

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -39,6 +39,7 @@ import org.apache.spark.network.util.JavaUtils
 import org.apache.spark.partial.{ApproximateActionListener, ApproximateEvaluator, PartialResult}
 import org.apache.spark.rdd.{DeterministicLevel, RDD, RDDCheckpointData}
 import org.apache.spark.rpc.RpcTimeout
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata
 import org.apache.spark.storage._
 import org.apache.spark.storage.BlockManagerMessages.BlockManagerHeartbeat
 import org.apache.spark.util._
@@ -1514,7 +1515,14 @@ private[spark] class DAGScheduler(
             }
         }
 
-      case FetchFailed(bmAddress, shuffleId, _, mapIndex, _, failureMessage) =>
+      case FetchFailed(
+          bmAddress,
+          shuffleId,
+          mapId,
+          mapIndex,
+          reduceId,
+          failureMessage,
+          blockMetadata) =>
         val failedStage = stageIdToStage(task.stageId)
         val mapStage = shuffleIdToMapStage(shuffleId)
 
@@ -1547,7 +1555,7 @@ private[spark] class DAGScheduler(
             mapOutputTracker.unregisterAllMapOutput(shuffleId)
           } else if (mapIndex != -1) {
             // Mark the map whose fetch failed as broken in the map stage
-            mapOutputTracker.unregisterMapOutput(shuffleId, mapIndex, bmAddress)
+            mapOutputTracker.removeMapOutput(shuffleId, mapIndex, bmAddress)
           }
 
           if (failedStage.rdd.isBarrier()) {
@@ -1683,11 +1691,15 @@ private[spark] class DAGScheduler(
               // reason to believe shuffle data has been lost for the entire host).
               None
             }
-            removeExecutorAndUnregisterOutputs(
+            removeMapOutputsForFetchFailure(
+              shuffleId,
+              mapIndex,
+              reduceId,
+              mapId,
+              blockMetadata,
+              task.epoch,
               execId = bmAddress.executorId,
-              fileLost = true,
-              hostToUnregisterOutputs = hostToUnregisterOutputs,
-              maybeEpoch = Some(task.epoch))
+              hostToUnregisterOutputs = hostToUnregisterOutputs)
           }
         }
 
@@ -1825,41 +1837,51 @@ private[spark] class DAGScheduler(
    * Optionally the epoch during which the failure was caught can be passed to avoid allowing
    * stray fetch failures from possibly retriggering the detection of a node as lost.
    */
-  private[scheduler] def handleExecutorLost(
-      execId: String,
-      workerLost: Boolean): Unit = {
+  private[scheduler] def handleExecutorLost(execId: String, workerLost: Boolean): Unit = {
     // if the cluster manager explicitly tells us that the entire worker was lost, then
     // we know to unregister shuffle output.  (Note that "worker" specifically refers to the process
     // from a Standalone cluster, where the shuffle service lives in the Worker.)
     val fileLost = workerLost || !env.blockManager.externalShuffleServiceEnabled
-    removeExecutorAndUnregisterOutputs(
-      execId = execId,
-      fileLost = fileLost,
-      hostToUnregisterOutputs = None,
-      maybeEpoch = None)
+    removeExecutorAndUnregisterOutputs(execId = execId, fileLost = fileLost)
   }
 
-  private def removeExecutorAndUnregisterOutputs(
+  private def removeMapOutputsForFetchFailure(
+      shuffleId: Int,
+      mapIndex: Int,
+      reduceId: Int,
+      mapId: Long,
+      blockMetadata: Option[ShuffleBlockMetadata],
+      taskEpoch: Long,
       execId: String,
-      fileLost: Boolean,
-      hostToUnregisterOutputs: Option[String],
-      maybeEpoch: Option[Long] = None): Unit = {
-    val currentEpoch = maybeEpoch.getOrElse(mapOutputTracker.getEpoch)
+      hostToUnregisterOutputs: Option[String]): Unit = {
+    if (!failedEpoch.contains(execId) || failedEpoch(execId) < taskEpoch) {
+      failedEpoch(execId) = taskEpoch
+      logInfo("Executor lost: %s (epoch %d)".format(execId, taskEpoch))
+      blockManagerMaster.removeExecutor(execId)
+      hostToUnregisterOutputs match {
+        case Some(host) =>
+          logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, taskEpoch))
+          mapOutputTracker.handleFetchFailureByHost(
+            shuffleId, mapIndex, reduceId, mapId, blockMetadata, host)
+        case None =>
+          logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, taskEpoch))
+          mapOutputTracker.handleFetchFailureByExecutor(
+            shuffleId, mapIndex, reduceId, mapId, blockMetadata, execId)
+      }
+      clearCacheLocs()
+    }
+  }
+
+  private def removeExecutorAndUnregisterOutputs(execId: String, fileLost: Boolean): Unit = {
+    val currentEpoch = mapOutputTracker.getEpoch
     if (!failedEpoch.contains(execId) || failedEpoch(execId) < currentEpoch) {
       failedEpoch(execId) = currentEpoch
       logInfo("Executor lost: %s (epoch %d)".format(execId, currentEpoch))
       blockManagerMaster.removeExecutor(execId)
       if (fileLost) {
-        hostToUnregisterOutputs match {
-          case Some(host) =>
-            logInfo("Shuffle files lost for host: %s (epoch %d)".format(host, currentEpoch))
-            mapOutputTracker.removeOutputsOnHost(host)
-          case None =>
-            logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
-            mapOutputTracker.removeOutputsOnExecutor(execId)
-        }
+        logInfo("Shuffle files lost for executor: %s (epoch %d)".format(execId, currentEpoch))
+        mapOutputTracker.removeOutputsByExecutor(execId)
         clearCacheLocs()
-
       } else {
         logDebug("Additional executor lost message for %s (epoch %d)".format(execId, currentEpoch))
       }
@@ -1882,7 +1904,7 @@ private[spark] class DAGScheduler(
       host: String,
       message: String): Unit = {
     logInfo("Shuffle files lost for worker %s on host %s".format(workerId, host))
-    mapOutputTracker.removeOutputsOnHost(host)
+    mapOutputTracker.removeOutputsByHost(host)
     clearCacheLocs()
   }
 

--- a/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/DAGScheduler.scala
@@ -1469,8 +1469,8 @@ private[spark] class DAGScheduler(
           case smt: ShuffleMapTask =>
             val shuffleStage = stage.asInstanceOf[ShuffleMapStage]
             shuffleStage.pendingPartitions -= task.partitionId
-            val status = event.result.asInstanceOf[MapStatus]
-            val execId = status.location.executorId
+            val mapTaskResult = event.result.asInstanceOf[MapTaskResult]
+            val execId = mapTaskResult.mapStatus.location.executorId
             logDebug("ShuffleMapTask finished on " + execId)
             if (failedEpoch.contains(execId) && smt.epoch <= failedEpoch(execId)) {
               logInfo(s"Ignoring possibly bogus $smt completion from executor $execId")
@@ -1479,7 +1479,7 @@ private[spark] class DAGScheduler(
               // recent failure we're aware of for the executor), so mark the task's output as
               // available.
               mapOutputTracker.registerMapOutput(
-                shuffleStage.shuffleDep.shuffleId, smt.partitionId, status)
+                shuffleStage.shuffleDep.shuffleId, smt.partitionId, mapTaskResult)
             }
 
             if (runningStages.contains(shuffleStage) && shuffleStage.pendingPartitions.isEmpty) {

--- a/core/src/main/scala/org/apache/spark/scheduler/MapTaskResult.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/MapTaskResult.scala
@@ -15,25 +15,9 @@
  * limitations under the License.
  */
 
-package org.apache.spark.shuffle.api;
+package org.apache.spark.scheduler
 
-import java.io.File;
-import java.io.IOException;
-import java.util.Optional;
+import org.apache.spark.shuffle.api.metadata.MapOutputMetadata
 
-import org.apache.spark.annotation.Private;
-import org.apache.spark.shuffle.api.metadata.MapOutputMetadata;
-
-/**
- * Optional extension for partition writing that is optimized for transferring a single
- * file to the backing store.
- */
-@Private
-public interface SingleSpillShuffleMapOutputWriter {
-
-  /**
-   * Transfer a file that contains the bytes of all the partitions written by this map task.
-   */
-  Optional<MapOutputMetadata> transferMapSpillFile(File mapOutputFile, long[] partitionLengths)
-      throws IOException;
-}
+private[spark] case class MapTaskResult(
+    mapStatus: MapStatus, metadata: Option[MapOutputMetadata])

--- a/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
+++ b/core/src/main/scala/org/apache/spark/scheduler/ShuffleMapTask.scala
@@ -61,7 +61,7 @@ private[spark] class ShuffleMapTask(
     appId: Option[String] = None,
     appAttemptId: Option[String] = None,
     isBarrier: Boolean = false)
-  extends Task[MapStatus](stageId, stageAttemptId, partition.index, localProperties,
+  extends Task[MapTaskResult](stageId, stageAttemptId, partition.index, localProperties,
     serializedTaskMetrics, jobId, appId, appAttemptId, isBarrier)
   with Logging {
 
@@ -74,7 +74,7 @@ private[spark] class ShuffleMapTask(
     if (locs == null) Nil else locs.distinct
   }
 
-  override def runTask(context: TaskContext): MapStatus = {
+  override def runTask(context: TaskContext): MapTaskResult = {
     // Deserialize the RDD using the broadcast variable.
     val threadMXBean = ManagementFactory.getThreadMXBean
     val deserializeStartTimeNs = System.nanoTime()

--- a/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/FetchFailedException.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.shuffle
 
 import org.apache.spark.{FetchFailed, TaskContext, TaskFailedReason}
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata
 import org.apache.spark.storage.BlockManagerId
 import org.apache.spark.util.Utils
 
@@ -39,7 +40,8 @@ private[spark] class FetchFailedException(
     mapIndex: Int,
     reduceId: Int,
     message: String,
-    cause: Throwable = null)
+    cause: Throwable = null,
+    blockMetadata: Option[ShuffleBlockMetadata] = None)
   extends Exception(message, cause) {
 
   def this(
@@ -50,6 +52,18 @@ private[spark] class FetchFailedException(
       reduceId: Int,
       cause: Throwable) {
     this(bmAddress, shuffleId, mapTaskId, mapIndex, reduceId, cause.getMessage, cause)
+  }
+
+  def this(
+      bmAddress: BlockManagerId,
+      shuffleId: Int,
+      mapTaskId: Long,
+      mapIndex: Int,
+      reduceId: Int,
+      cause: Throwable,
+      blockMetadata: Option[ShuffleBlockMetadata]) {
+    this(
+      bmAddress, shuffleId, mapTaskId, mapIndex, reduceId, cause.getMessage, cause, blockMetadata)
   }
 
   // SPARK-19276. We set the fetch failure in the task context, so that even if there is user-code

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockFetcherIterable.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleBlockFetcherIterable.scala
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle
+
+import java.lang.{Iterable => JIterable}
+import java.util.{Iterator => JIterator}
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.{ShuffleDependency, SparkConf, TaskContext}
+import org.apache.spark.internal.Logging
+import org.apache.spark.internal.config._
+import org.apache.spark.io.CompressionCodec
+import org.apache.spark.serializer.SerializerManager
+import org.apache.spark.shuffle.api.io.ShuffleBlockInputStream
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockInfo
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleBlockMetadata
+import org.apache.spark.storage.{BlockId, BlockManager, ShuffleBlockFetcherIterator, ShuffleBlockId}
+
+private[spark] class ShuffleBlockFetcherIterable(
+    blocks: JIterable[ShuffleBlockInfo],
+    context: TaskContext,
+    blockManager: BlockManager,
+    serializerManager: SerializerManager,
+    conf: SparkConf,
+    shouldBatchFetch: Boolean,
+    dep: ShuffleDependency[_, _, _])
+    extends JIterable[ShuffleBlockInputStream] with Logging {
+
+  private def fetchContinuousBlocksInBatch: Boolean = {
+    val serializerRelocatable = dep.serializer.supportsRelocationOfSerializedObjects
+    val compressed = conf.get(SHUFFLE_COMPRESS)
+    val codecConcatenation = if (compressed) {
+      CompressionCodec.supportsConcatenationOfSerializedStreams(CompressionCodec.createCodec(conf))
+    } else {
+      true
+    }
+    val useOldFetchProtocol = conf.get(SHUFFLE_USE_OLD_FETCH_PROTOCOL)
+
+    val doBatchFetch = this.shouldBatchFetch && serializerRelocatable &&
+      (!compressed || codecConcatenation) && !useOldFetchProtocol
+    if (shouldBatchFetch && !doBatchFetch) {
+      logDebug("The feature tag of continuous shuffle block fetching is set to true, but " +
+        "we can not enable the feature because other conditions are not satisfied. " +
+        s"Shuffle compress: $compressed, serializer relocatable: $serializerRelocatable, " +
+        s"codec concatenation: $codecConcatenation, use old shuffle fetch protocol: " +
+        s"$useOldFetchProtocol.")
+    }
+    doBatchFetch
+  }
+
+  override def iterator(): JIterator[ShuffleBlockInputStream] = {
+    new ShuffleBlockFetcherIterator(
+      context,
+      blockManager.blockStoreClient,
+      blockManager,
+      blocks.asScala
+        .groupBy(shuffleBlockInfo => shuffleBlockInfo.getShuffleLocation())
+        .map{ case (blockManagerId, shuffleBlockInfos) =>
+          (blockManagerId,
+            shuffleBlockInfos.map(info =>
+              (ShuffleBlockId(
+                info.getShuffleId,
+                info.getMapTaskAttemptId,
+                info.getReduceId).asInstanceOf[BlockId],
+                info.getBlockLength,
+                info.getMapIndex)).toSeq)
+        }
+        .iterator,
+      serializerManager.wrapStream,
+      // Note: we use getSizeAsMb when no suffix is provided for backwards compatibility
+      conf.get(REDUCER_MAX_SIZE_IN_FLIGHT) * 1024 * 1024,
+      conf.get(REDUCER_MAX_REQS_IN_FLIGHT),
+      conf.get(REDUCER_MAX_BLOCKS_IN_FLIGHT_PER_ADDRESS),
+      conf.get(MAX_REMOTE_BLOCK_SIZE_FETCH_TO_MEM),
+      conf.get(SHUFFLE_DETECT_CORRUPT),
+      conf.get(SHUFFLE_DETECT_CORRUPT_MEMORY),
+      context.taskMetrics().createTempShuffleReadMetrics(),
+      fetchContinuousBlocksInBatch)
+      .toCompletionIterator
+      .map {
+        case (blockId, stream) =>
+          ShuffleBlockInputStream.of(stream, new LocalDiskShuffleBlockMetadata(blockId))
+      }
+      .asJava
+  }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriteProcessor.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriteProcessor.scala
@@ -20,7 +20,7 @@ package org.apache.spark.shuffle
 import org.apache.spark.{Partition, ShuffleDependency, SparkEnv, TaskContext}
 import org.apache.spark.internal.Logging
 import org.apache.spark.rdd.RDD
-import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.scheduler.{MapStatus, MapTaskResult}
 
 /**
  * The interface for customizing shuffle write process. The driver create a ShuffleWriteProcessor
@@ -46,7 +46,7 @@ private[spark] class ShuffleWriteProcessor extends Serializable with Logging {
       dep: ShuffleDependency[_, _, _],
       mapId: Long,
       context: TaskContext,
-      partition: Partition): MapStatus = {
+      partition: Partition): MapTaskResult = {
     var writer: ShuffleWriter[Any, Any] = null
     try {
       val manager = SparkEnv.get.shuffleManager

--- a/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/ShuffleWriter.scala
@@ -19,7 +19,7 @@ package org.apache.spark.shuffle
 
 import java.io.IOException
 
-import org.apache.spark.scheduler.MapStatus
+import org.apache.spark.scheduler.MapTaskResult
 
 /**
  * Obtained inside a map task to write out records to the shuffle system.
@@ -30,5 +30,5 @@ private[spark] abstract class ShuffleWriter[K, V] {
   def write(records: Iterator[Product2[K, V]]): Unit
 
   /** Close this writer, passing along whether the map completed */
-  def stop(success: Boolean): Option[MapStatus]
+  def stop(success: Boolean): Option[MapTaskResult]
 }

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleManager.scala
@@ -127,8 +127,8 @@ private[spark] class SortShuffleManager(conf: SparkConf) extends ShuffleManager 
     val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByExecutorId(
       handle.shuffleId, startPartition, endPartition)
     new BlockStoreShuffleReader(
-      handle.asInstanceOf[BaseShuffleHandle[K, _, C]], blocksByAddress, context, metrics,
-      shouldBatchFetch = canUseBatchFetch(startPartition, endPartition, context))
+      handle.asInstanceOf[BaseShuffleHandle[K, _, C]], blocksByAddress, startPartition,
+      endPartition, context, metrics, shuffleExecutorComponents)
   }
 
   override def getReaderForRange[K, C](
@@ -142,7 +142,8 @@ private[spark] class SortShuffleManager(conf: SparkConf) extends ShuffleManager 
     val blocksByAddress = SparkEnv.get.mapOutputTracker.getMapSizesByRange(
       handle.shuffleId, startMapIndex, endMapIndex, startPartition, endPartition)
     new BlockStoreShuffleReader(
-      handle.asInstanceOf[BaseShuffleHandle[K, _, C]], blocksByAddress, context, metrics,
+      handle.asInstanceOf[BaseShuffleHandle[K, _, C]], blocksByAddress, startPartition,
+      endPartition, context, metrics, shuffleExecutorComponents,
       shouldBatchFetch = canUseBatchFetch(startPartition, endPartition, context))
   }
 

--- a/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/sort/SortShuffleWriter.scala
@@ -67,7 +67,7 @@ private[spark] class SortShuffleWriter[K, V, C](
     val mapOutputWriter = shuffleExecutorComponents.createMapOutputWriter(
       dep.shuffleId, mapId, dep.partitioner.numPartitions)
     sorter.writePartitionedMapOutput(dep.shuffleId, mapId, mapOutputWriter)
-    val partitionLengths = mapOutputWriter.commitAllPartitions()
+    val partitionLengths = mapOutputWriter.commitAllPartitions().getPartitionLengths
     mapStatus = MapStatus(blockManager.shuffleServerId, partitionLengths, mapId)
   }
 

--- a/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveEndpoint.scala
+++ b/core/src/main/scala/org/apache/spark/storage/BlockManagerSlaveEndpoint.scala
@@ -56,7 +56,7 @@ class BlockManagerSlaveEndpoint(
     case RemoveShuffle(shuffleId) =>
       doAsync[Boolean]("removing shuffle " + shuffleId, context) {
         if (mapOutputTracker != null) {
-          mapOutputTracker.unregisterShuffle(shuffleId)
+          mapOutputTracker.unregisterShuffle(shuffleId, true)
         }
         SparkEnv.get.shuffleManager.unregisterShuffle(shuffleId)
       }

--- a/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
+++ b/core/src/main/scala/org/apache/spark/storage/ShuffleBlockFetcherIterator.scala
@@ -34,6 +34,7 @@ import org.apache.spark.network.buffer.{FileSegmentManagedBuffer, ManagedBuffer}
 import org.apache.spark.network.shuffle._
 import org.apache.spark.network.util.TransportConf
 import org.apache.spark.shuffle.{FetchFailedException, ShuffleReadMetricsReporter}
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleBlockMetadata
 import org.apache.spark.util.{CompletionIterator, TaskCompletionListener, Utils}
 
 /**
@@ -743,11 +744,27 @@ final class ShuffleBlockFetcherIterator(
       mapIndex: Int,
       address: BlockManagerId,
       e: Throwable) = {
+    val metadata = new LocalDiskShuffleBlockMetadata(blockId)
     blockId match {
       case ShuffleBlockId(shufId, mapId, reduceId) =>
-        throw new FetchFailedException(address, shufId, mapId, mapIndex, reduceId, e)
+        throw new FetchFailedException(
+          address,
+          shufId,
+          mapId,
+          mapIndex,
+          reduceId,
+          e,
+          Some(metadata))
+
       case ShuffleBlockBatchId(shuffleId, mapId, startReduceId, _) =>
-        throw new FetchFailedException(address, shuffleId, mapId, mapIndex, startReduceId, e)
+        throw new FetchFailedException(
+          address,
+          shuffleId,
+          mapId,
+          mapIndex,
+          startReduceId,
+          e,
+          Some(metadata))
       case _ =>
         throw new SparkException(
           "Failed to get block " + blockId + ", which is not a shuffle block", e)

--- a/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
+++ b/core/src/main/scala/org/apache/spark/util/JsonProtocol.scala
@@ -36,6 +36,7 @@ import org.apache.spark.rdd.RDDOperationScope
 import org.apache.spark.resource.ResourceInformation
 import org.apache.spark.scheduler._
 import org.apache.spark.scheduler.cluster.ExecutorInfo
+import org.apache.spark.shuffle.api.metadata.ShuffleBlockMetadata
 import org.apache.spark.storage._
 
 /**
@@ -419,12 +420,17 @@ private[spark] object JsonProtocol {
       case fetchFailed: FetchFailed =>
         val blockManagerAddress = Option(fetchFailed.bmAddress).
           map(blockManagerIdToJson).getOrElse(JNothing)
+        val shuffleBlockMetadata = fetchFailed
+          .blockMetadata
+          .map(shuffleBlockMetadataToJson)
+          .getOrElse(JNothing)
         ("Block Manager Address" -> blockManagerAddress) ~
         ("Shuffle ID" -> fetchFailed.shuffleId) ~
         ("Map ID" -> fetchFailed.mapId) ~
         ("Map Index" -> fetchFailed.mapIndex) ~
         ("Reduce ID" -> fetchFailed.reduceId) ~
-        ("Message" -> fetchFailed.message)
+        ("Message" -> fetchFailed.message) ~
+        ("Block Metadata" -> shuffleBlockMetadata)
       case exceptionFailure: ExceptionFailure =>
         val stackTrace = stackTraceToJson(exceptionFailure.stackTrace)
         val accumUpdates = accumulablesToJson(exceptionFailure.accumUpdates)
@@ -454,6 +460,10 @@ private[spark] object JsonProtocol {
     ("Executor ID" -> blockManagerId.executorId) ~
     ("Host" -> blockManagerId.host) ~
     ("Port" -> blockManagerId.port)
+  }
+
+  def shuffleBlockMetadataToJson(shuffleBlockMetadata: ShuffleBlockMetadata): JValue = {
+    ("Metadata" -> shuffleBlockMetadata.toPrintableString)
   }
 
   def jobResultToJson(jobResult: JobResult): JValue = {

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -79,6 +79,7 @@ public class UnsafeShuffleWriterSuite {
   SparkConf conf;
   final Serializer serializer = new KryoSerializer(new SparkConf());
   TaskMetrics taskMetrics;
+  LocalDiskShuffleExecutorComponents shuffleExecutorComponents;
 
   @Mock(answer = RETURNS_SMART_NULLS) BlockManager blockManager;
   @Mock(answer = RETURNS_SMART_NULLS) IndexShuffleBlockResolver shuffleBlockResolver;
@@ -169,6 +170,8 @@ public class UnsafeShuffleWriterSuite {
     when(shuffleDep.serializer()).thenReturn(serializer);
     when(shuffleDep.partitioner()).thenReturn(hashPartitioner);
     when(taskContext.taskMemoryManager()).thenReturn(taskMemoryManager);
+    shuffleExecutorComponents = new LocalDiskShuffleExecutorComponents(
+        conf, blockManager, manager, shuffleBlockResolver);
   }
 
   private UnsafeShuffleWriter<Object, Object> createWriter(boolean transferToEnabled) {
@@ -181,7 +184,7 @@ public class UnsafeShuffleWriterSuite {
       taskContext,
       conf,
       taskContext.taskMetrics().shuffleWriteMetrics(),
-      new LocalDiskShuffleExecutorComponents(conf, blockManager, shuffleBlockResolver));
+      shuffleExecutorComponents);
   }
 
   private void assertSpillFilesWereCleanedUp() {
@@ -540,7 +543,7 @@ public class UnsafeShuffleWriterSuite {
         taskContext,
         conf,
         taskContext.taskMetrics().shuffleWriteMetrics(),
-        new LocalDiskShuffleExecutorComponents(conf, blockManager, shuffleBlockResolver));
+        shuffleExecutorComponents);
 
     // Peak memory should be monotonically increasing. More specifically, every time
     // we allocate a new page it should increase by exactly the size of the page.

--- a/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/shuffle/sort/UnsafeShuffleWriterSuite.java
@@ -50,7 +50,7 @@ import org.apache.spark.internal.config.package$;
 import org.apache.spark.memory.TaskMemoryManager;
 import org.apache.spark.memory.TestMemoryManager;
 import org.apache.spark.network.util.LimitedInputStream;
-import org.apache.spark.scheduler.MapStatus;
+import org.apache.spark.scheduler.MapTaskResult;
 import org.apache.spark.security.CryptoStreamUtils;
 import org.apache.spark.serializer.*;
 import org.apache.spark.shuffle.IndexShuffleBlockResolver;
@@ -249,7 +249,7 @@ public class UnsafeShuffleWriterSuite {
   public void writeEmptyIterator() throws Exception {
     final UnsafeShuffleWriter<Object, Object> writer = createWriter(true);
     writer.write(new ArrayList<Product2<Object, Object>>().iterator());
-    final Option<MapStatus> mapStatus = writer.stop(true);
+    final Option<MapTaskResult> mapStatus = writer.stop(true);
     assertTrue(mapStatus.isDefined());
     assertTrue(mergedOutputFile.exists());
     assertEquals(0, spillFilesCreated.size());
@@ -269,7 +269,7 @@ public class UnsafeShuffleWriterSuite {
     }
     final UnsafeShuffleWriter<Object, Object> writer = createWriter(true);
     writer.write(dataToWrite.iterator());
-    final Option<MapStatus> mapStatus = writer.stop(true);
+    final Option<MapTaskResult> mapStatus = writer.stop(true);
     assertTrue(mapStatus.isDefined());
     assertTrue(mergedOutputFile.exists());
 
@@ -331,7 +331,7 @@ public class UnsafeShuffleWriterSuite {
     writer.insertRecordIntoSorter(dataToWrite.get(4));
     writer.insertRecordIntoSorter(dataToWrite.get(5));
     writer.closeAndWriteOutput();
-    final Option<MapStatus> mapStatus = writer.stop(true);
+    final Option<MapTaskResult> mapStatus = writer.stop(true);
     assertTrue(mapStatus.isDefined());
     assertTrue(mergedOutputFile.exists());
     assertEquals(2, spillFilesCreated.size());

--- a/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
+++ b/core/src/test/scala/org/apache/spark/InternalAccumulatorSuite.scala
@@ -212,7 +212,7 @@ class InternalAccumulatorSuite extends SparkFunSuite with LocalSparkContext {
    * A special [[ContextCleaner]] that saves the IDs of the accumulators registered for cleanup.
    */
   private class SaveAccumContextCleaner(sc: SparkContext) extends
-      ContextCleaner(sc, null) {
+      ContextCleaner(sc) {
     private val accumsRegistered = new ArrayBuffer[Long]
 
     override def registerAccumulatorForCleanup(a: AccumulatorV2[_, _]): Unit = {

--- a/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/MapOutputTrackerSuite.scala
@@ -75,7 +75,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
       MapTaskResult(
         MapStatus(BlockManagerId("b", "hostB", 1000), Array(10000L, 1000L), 6), None))
     val statuses = tracker.getMapSizesByExecutorId(10, 0)
-    assert(statuses.toSet ===
+    assert(statuses.blocks.toSet ===
       Seq((BlockManagerId("a", "hostA", 1000),
         ArrayBuffer((ShuffleBlockId(10, 5, 0), size1000, 0))),
           (BlockManagerId("b", "hostB", 1000),
@@ -109,11 +109,11 @@ class MapOutputTrackerSuite extends SparkFunSuite {
           BlockManagerId("b", "hostB", 1000),
           Array(compressedSize10000, compressedSize1000), 6), None))
     assert(tracker.containsShuffle(10))
-    assert(tracker.getMapSizesByExecutorId(10, 0).nonEmpty)
+    assert(tracker.getMapSizesByExecutorId(10, 0).blocks.nonEmpty)
     assert(0 == tracker.getNumCachedSerializedBroadcast)
     tracker.unregisterShuffle(10, true)
     assert(!tracker.containsShuffle(10))
-    assert(tracker.getMapSizesByExecutorId(10, 0).isEmpty)
+    assert(tracker.getMapSizesByExecutorId(10, 0).blocks.isEmpty)
 
     tracker.stop()
     rpcEnv.shutdown()
@@ -184,7 +184,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
         MapStatus(BlockManagerId("a", "hostA", 1000), Array(1000L), 5),
         None))
     slaveTracker.updateEpoch(masterTracker.getEpoch)
-    assert(slaveTracker.getMapSizesByExecutorId(10, 0).toSeq ===
+    assert(slaveTracker.getMapSizesByExecutorId(10, 0).blocks.toSeq ===
       Seq((BlockManagerId("a", "hostA", 1000),
         ArrayBuffer((ShuffleBlockId(10, 5, 0), size1000, 0)))))
     assert(0 == masterTracker.getNumCachedSerializedBroadcast)
@@ -380,7 +380,7 @@ class MapOutputTrackerSuite extends SparkFunSuite {
         MapStatus(BlockManagerId("b", "hostB", 1000), Array(size10000, size0, size1000, size0), 6),
         None))
     assert(tracker.containsShuffle(10))
-    assert(tracker.getMapSizesByExecutorId(10, 0, 4).toSeq ===
+    assert(tracker.getMapSizesByExecutorId(10, 0, 4).blocks.toSeq ===
         Seq(
           (BlockManagerId("a", "hostA", 1000),
               Seq((ShuffleBlockId(10, 5, 1), size1000, 0),

--- a/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
+++ b/core/src/test/scala/org/apache/spark/MapStatusesSerDeserBenchmark.scala
@@ -17,10 +17,12 @@
 
 package org.apache.spark
 
+import org.mockito.Mockito
 import org.scalatest.Assertions._
 
 import org.apache.spark.benchmark.Benchmark
 import org.apache.spark.benchmark.BenchmarkBase
+import org.apache.spark.rdd.RDD
 import org.apache.spark.scheduler.{CompressedMapStatus, MapTaskResult}
 import org.apache.spark.storage.BlockManagerId
 

--- a/core/src/test/scala/org/apache/spark/ShuffleStoragePluginSuite.scala
+++ b/core/src/test/scala/org/apache/spark/ShuffleStoragePluginSuite.scala
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark
+
+import org.apache.spark.shuffle.io.plugin.MockAsyncBackupShuffleDataIO
+
+class ShuffleStoragePluginSuite extends SortShuffleSuite {
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    conf.set(
+      org.apache.spark.internal.config.SHUFFLE_IO_PLUGIN_CLASS,
+      classOf[MockAsyncBackupShuffleDataIO].getName())
+  }
+}

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -2944,7 +2944,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       taskSets(2).tasks(0),
       FetchFailed(makeBlockManagerId("hostB"), shuffleId2, 0L, 0, 0, "ignored"),
       null))
-    mapOutputTracker.removeOutputsOnHost("hostB")
+    mapOutputTracker.removeOutputsByHost("hostB")
 
     assert(scheduler.failedStages.toSeq.map(_.id) == Seq(1, 2))
     scheduler.resubmitFailedStages()

--- a/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/DAGSchedulerSuite.scala
@@ -455,9 +455,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(mapStageC.parents === List(mapStageA, mapStageB))
     assert(finalStage.parents === List(mapStageC))
 
-    complete(taskSets(0), Seq((Success, makeMapStatus("hostA", 1))))
-    complete(taskSets(1), Seq((Success, makeMapStatus("hostA", 1))))
-    complete(taskSets(2), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(0), Seq((Success, makeMapTaskResult("hostA", 1))))
+    complete(taskSets(1), Seq((Success, makeMapTaskResult("hostA", 1))))
+    complete(taskSets(2), Seq((Success, makeMapTaskResult("hostA", 1))))
     complete(taskSets(3), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
     assertDataStructuresEmpty()
@@ -484,23 +484,29 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // map stage1 completes successfully, with one task on each executor
     complete(taskSets(0), Seq(
       (Success,
-        MapStatus(
-          BlockManagerId("exec-hostA1", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 5)),
+        MapTaskResult(
+          MapStatus(
+            BlockManagerId("exec-hostA1", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 5),
+          None)),
       (Success,
-        MapStatus(
-          BlockManagerId("exec-hostA2", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 6)),
-      (Success, makeMapStatus("hostB", 1, mapTaskId = 7))
-    ))
+        MapTaskResult(
+          MapStatus(
+            BlockManagerId("exec-hostA2", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 6),
+          None)),
+      (Success, makeMapTaskResult("hostB", 1, mapTaskId = 7))))
     // map stage2 completes successfully, with one task on each executor
     complete(taskSets(1), Seq(
       (Success,
-        MapStatus(
-          BlockManagerId("exec-hostA1", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 8)),
+        MapTaskResult(
+          MapStatus(
+            BlockManagerId("exec-hostA1", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 8),
+          None)),
       (Success,
-        MapStatus(
-          BlockManagerId("exec-hostA2", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 9)),
-      (Success, makeMapStatus("hostB", 1, mapTaskId = 10))
-    ))
+        MapTaskResult(
+          MapStatus(
+            BlockManagerId("exec-hostA2", "hostA", 12345), Array.fill[Long](1)(2), mapTaskId = 9),
+          None)),
+      (Success, makeMapTaskResult("hostB", 1, mapTaskId = 10))))
     // make sure our test setup is correct
     val initialMapStatus1 = mapOutputTracker.shuffleStatuses(firstShuffleId).mapStatuses
     //  val initialMapStatus1 = mapOutputTracker.mapStatuses.get(0).get
@@ -740,9 +746,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 1, List(shuffleDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 1)),
-      (Success, makeMapStatus("hostB", 1))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostA", 1)),
+      (Success, makeMapTaskResult("hostB", 1))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
     complete(taskSets(1), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
@@ -756,8 +762,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0, 1))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
+      (Success, makeMapTaskResult("hostA", reduceRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length))))
     // the 2nd ResultTask failed
     complete(taskSets(1), Seq(
       (Success, 42),
@@ -767,9 +773,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // ask the scheduler to try it again
     scheduler.resubmitFailedStages()
     // have the 2nd attempt pass
-    complete(taskSets(2), Seq((Success, makeMapStatus("hostA", reduceRdd.partitions.length))))
+    complete(taskSets(2), Seq((Success, makeMapTaskResult("hostA", reduceRdd.partitions.length))))
     // we can see both result blocks now
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1.host).toSet ===
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1.host).toSet ===
       HashSet("hostA", "hostB"))
     complete(taskSets(3), Seq((Success, 43)))
     assert(results === Map(0 -> 42, 1 -> 43))
@@ -803,15 +809,15 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       val reduceRdd = new MyRDD(sc, 1, List(shuffleDep), tracker = mapOutputTracker)
       submit(reduceRdd, Array(0))
       complete(taskSets(0), Seq(
-        (Success, makeMapStatus("hostA", 1)),
-        (Success, makeMapStatus("hostB", 1))))
+        (Success, makeMapTaskResult("hostA", 1)),
+        (Success, makeMapTaskResult("hostB", 1))))
       runEvent(ExecutorLost("exec-hostA", event))
       if (expectFileLoss) {
         intercept[MetadataFetchFailedException] {
           mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0)
         }
       } else {
-        assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
+        assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1).toSet ===
           HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
       }
     }
@@ -894,7 +900,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     checkStageId(stageId, attemptIdx, stageAttempt)
     complete(stageAttempt, stageAttempt.tasks.zipWithIndex.map {
       case (task, idx) =>
-        (Success, makeMapStatus("host" + ('A' + idx).toChar, numShufflePartitions))
+        (Success, makeMapTaskResult("host" + ('A' + idx).toChar, numShufflePartitions))
     }.toSeq)
   }
 
@@ -1137,10 +1143,10 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0, 1))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
+      (Success, makeMapTaskResult("hostA", reduceRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length))))
     // The MapOutputTracker should know about both map output locations.
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1.host).toSet ===
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1.host).toSet ===
       HashSet("hostA", "hostB"))
 
     // The first result task fails, with a fetch failure for the output from the first mapper.
@@ -1166,8 +1172,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0, 1))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
+      (Success, makeMapTaskResult("hostA", reduceRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
 
     // The first result task fails, with a fetch failure for the output from the first mapper.
@@ -1195,7 +1201,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 2, List(shuffleDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0, 1))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", reduceRdd.partitions.length))))
+      (Success, makeMapTaskResult("hostA", reduceRdd.partitions.length))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq(1)))
 
     // The second map task fails with TaskKilled.
@@ -1228,8 +1234,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Complete the map stage.
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostA", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostA", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
 
     // The first ResultTask fails
@@ -1264,12 +1270,12 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(countSubmittedMapStageAttempts() === 1)
 
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
     // The MapOutputTracker should know about both map output locations.
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1.host).toSet ===
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1.host).toSet ===
       HashSet("hostA", "hostB"))
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 1).map(_._1.host).toSet ===
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 1).blocks.map(_._1.host).toSet ===
       HashSet("hostA", "hostB"))
 
     // The first result task fails, with a fetch failure for the output from the first mapper.
@@ -1325,8 +1331,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Complete the map stage.
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
 
     // The reduce stage should have been submitted.
     assert(countSubmittedReduceStageAttempts() === 1)
@@ -1339,7 +1345,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Trigger resubmission of the failed map stage and finish the re-started map task.
     runEvent(ResubmitFailedStages)
-    complete(taskSets(2), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(2), Seq((Success, makeMapTaskResult("hostA", 1))))
 
     // Because the map stage finished, another attempt for the reduce stage should have been
     // submitted, resulting in 2 total attempts for each the map and the reduce stage.
@@ -1425,21 +1431,21 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     runEvent(makeCompletionEvent(
       taskSet.tasks(0),
       Success,
-      makeMapStatus("hostA", reduceRdd.partitions.size)))
+      makeMapTaskResult("hostA", reduceRdd.partitions.size)))
     assert(shuffleStage.numAvailableOutputs === 0)
 
     // should work because it's a non-failed host (so the available map outputs will increase)
     runEvent(makeCompletionEvent(
       taskSet.tasks(0),
       Success,
-      makeMapStatus("hostB", reduceRdd.partitions.size)))
+      makeMapTaskResult("hostB", reduceRdd.partitions.size)))
     assert(shuffleStage.numAvailableOutputs === 1)
 
     // should be ignored for being too old
     runEvent(makeCompletionEvent(
       taskSet.tasks(0),
       Success,
-      makeMapStatus("hostA", reduceRdd.partitions.size)))
+      makeMapTaskResult("hostA", reduceRdd.partitions.size)))
     assert(shuffleStage.numAvailableOutputs === 1)
 
     // should work because it's a new epoch, which will increase the number of available map
@@ -1448,9 +1454,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     runEvent(makeCompletionEvent(
       taskSet.tasks(1),
       Success,
-      makeMapStatus("hostA", reduceRdd.partitions.size)))
+      makeMapTaskResult("hostA", reduceRdd.partitions.size)))
     assert(shuffleStage.numAvailableOutputs === 2)
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostB"), makeBlockManagerId("hostA")))
 
     // finish the next stage normally, which completes the job
@@ -1535,9 +1541,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // things start out smoothly, stage 0 completes with no issues
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostB", shuffleMapRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", shuffleMapRdd.partitions.length)),
-      (Success, makeMapStatus("hostA", shuffleMapRdd.partitions.length))
+      (Success, makeMapTaskResult("hostB", shuffleMapRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", shuffleMapRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostA", shuffleMapRdd.partitions.length))
     ))
 
     // then one executor dies, and a task fails in stage 1
@@ -1557,7 +1563,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     runEvent(makeCompletionEvent(
       task,
       Success,
-      makeMapStatus("hostC", shuffleMapRdd.partitions.length)))
+      makeMapTaskResult("hostC", shuffleMapRdd.partitions.length)))
 
     // now here is where things get tricky : we will now have a task set representing
     // the second attempt for stage 1, but we *also* have some tasks for the first attempt for
@@ -1573,16 +1579,16 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     runEvent(makeCompletionEvent(
       taskSets(3).tasks(0),
       Success,
-      makeMapStatus("hostC", reduceRdd.partitions.length)))
+      makeMapTaskResult("hostC", reduceRdd.partitions.length)))
     runEvent(makeCompletionEvent(
       taskSets(3).tasks(1),
       Success,
-      makeMapStatus("hostC", reduceRdd.partitions.length)))
+      makeMapTaskResult("hostC", reduceRdd.partitions.length)))
     // late task finish from the first attempt
     runEvent(makeCompletionEvent(
       taskSets(1).tasks(2),
       Success,
-      makeMapStatus("hostB", reduceRdd.partitions.length)))
+      makeMapTaskResult("hostB", reduceRdd.partitions.length)))
 
     // What should happen now is that we submit stage 2.  However, we might not see an error
     // b/c of DAGScheduler's error handling (it tends to swallow errors and just log them).  But
@@ -1608,7 +1614,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       // really we should have already thrown an exception rather than fail either of these
       // asserts, but just to be extra defensive let's double check the statuses are OK
       assert(statuses != null)
-      assert(statuses.nonEmpty)
+      assert(statuses.blocks.nonEmpty)
     }
 
     // and check that stage 2 has been submitted
@@ -1632,11 +1638,11 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     runEvent(makeCompletionEvent(
       taskSets(0).tasks(0),
       Success,
-      makeMapStatus("hostA", reduceRdd.partitions.length)))
+      makeMapTaskResult("hostA", reduceRdd.partitions.length)))
     runEvent(makeCompletionEvent(
       taskSets(0).tasks(1),
       Success,
-      makeMapStatus("hostA", reduceRdd.partitions.length)))
+      makeMapTaskResult("hostA", reduceRdd.partitions.length)))
 
     // now that host goes down
     runEvent(ExecutorLost("exec-hostA", ExecutorKilled))
@@ -1647,9 +1653,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // now complete everything on a different host
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length))
     ))
 
     // now we should submit stage 1, and the map output from stage 0 should be registered
@@ -1660,7 +1666,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       // really we should have already thrown an exception rather than fail either of these
       // asserts, but just to be extra defensive let's double check the statuses are OK
       assert(statuses != null)
-      assert(statuses.nonEmpty)
+      assert(statuses.blocks.nonEmpty)
     }
 
     // and check that stage 1 has been submitted
@@ -1729,7 +1735,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(taskSet.priority === priority)
   }
 
-  def launchJobsThatShareStageAndCancelFirst(): ShuffleDependency[Int, Int, Nothing] = {
+  def launchJobsThatShareStageAndCancelFirst(): ShuffleDependency[_, _, _] = {
     val baseRdd = new MyRDD(sc, 1, Nil)
     val shuffleDep1 = new ShuffleDependency(baseRdd, new HashPartitioner(1))
     val intermediateRdd = new MyRDD(sc, 1, List(shuffleDep1))
@@ -1764,7 +1770,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // correct behavior.
     val job1Id = 0  // TaskSet priority for Stages run with "job1" as the ActiveJob
     checkJobPropertiesAndPriority(taskSets(0), "job1", job1Id)
-    complete(taskSets(0), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(0), Seq((Success, makeMapTaskResult("hostA", 1))))
 
     shuffleDep1
   }
@@ -1781,7 +1787,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // the stage.
     checkJobPropertiesAndPriority(taskSets(1), "job2", 1)
 
-    complete(taskSets(1), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(1), Seq((Success, makeMapTaskResult("hostA", 1))))
     assert(taskSets(2).properties != null)
     complete(taskSets(2), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
@@ -1813,9 +1819,9 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     checkJobPropertiesAndPriority(taskSets(2), "job2", job2Id)
 
     // run the rest of the stages normally, checking that they have the correct properties
-    complete(taskSets(2), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(2), Seq((Success, makeMapTaskResult("hostA", 1))))
     checkJobPropertiesAndPriority(taskSets(3), "job2", job2Id)
-    complete(taskSets(3), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(3), Seq((Success, makeMapTaskResult("hostA", 1))))
     checkJobPropertiesAndPriority(taskSets(4), "job2", job2Id)
     complete(taskSets(4), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
@@ -1839,8 +1845,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Tell the DAGScheduler that hostA was lost.
     runEvent(ExecutorLost("exec-hostA", ExecutorKilled))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 1)),
-      (Success, makeMapStatus("hostB", 1))))
+      (Success, makeMapTaskResult("hostA", 1)),
+      (Success, makeMapTaskResult("hostB", 1))))
 
     // At this point, no more tasks are running for the stage (and the TaskSetManager considers the
     // stage complete), but the tasks that ran on HostA need to be re-run, so the DAGScheduler
@@ -1854,8 +1860,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(taskSets(1).tasks(0).isInstanceOf[ShuffleMapTask])
 
     // have hostC complete the resubmitted task
-    complete(taskSets(1), Seq((Success, makeMapStatus("hostC", 1))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
+    complete(taskSets(1), Seq((Success, makeMapTaskResult("hostC", 1))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostC"), makeBlockManagerId("hostB")))
 
     // Make sure that the reduce stage was now submitted.
@@ -1877,12 +1883,12 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     submit(finalRdd, Array(0))
     // have the first stage complete normally
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
     // have the second stage complete normally
     complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostA", 1)),
-      (Success, makeMapStatus("hostC", 1))))
+      (Success, makeMapTaskResult("hostA", 1)),
+      (Success, makeMapTaskResult("hostC", 1))))
     // fail the third stage because hostA went down
     complete(taskSets(2), Seq(
       (FetchFailed(makeBlockManagerId("hostA"),
@@ -1891,8 +1897,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // blockManagerMaster.removeExecutor("exec-hostA")
     // have DAGScheduler try again
     scheduler.resubmitFailedStages()
-    complete(taskSets(3), Seq((Success, makeMapStatus("hostA", 2))))
-    complete(taskSets(4), Seq((Success, makeMapStatus("hostA", 1))))
+    complete(taskSets(3), Seq((Success, makeMapTaskResult("hostA", 2))))
+    complete(taskSets(4), Seq((Success, makeMapTaskResult("hostA", 1))))
     complete(taskSets(5), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
     assertDataStructuresEmpty()
@@ -1909,12 +1915,12 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     cacheLocations(shuffleTwoRdd.id -> 1) = Seq(makeBlockManagerId("hostC"))
     // complete stage 0
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
     // complete stage 1
     complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostA", 1)),
-      (Success, makeMapStatus("hostB", 1))))
+      (Success, makeMapTaskResult("hostA", 1)),
+      (Success, makeMapTaskResult("hostB", 1))))
     // pretend stage 2 failed because hostA went down
     complete(taskSets(2), Seq(
       (FetchFailed(makeBlockManagerId("hostA"),
@@ -1925,7 +1931,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     scheduler.resubmitFailedStages()
     assertLocations(taskSets(3), Seq(Seq("hostD")))
     // allow hostD to recover
-    complete(taskSets(3), Seq((Success, makeMapStatus("hostD", 1))))
+    complete(taskSets(3), Seq((Success, makeMapTaskResult("hostD", 1))))
     complete(taskSets(4), Seq((Success, 42)))
     assert(results === Map(0 -> 42))
     assertDataStructuresEmpty()
@@ -2166,8 +2172,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 1, List(shuffleDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 1))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostA", 1))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostA")))
 
     // Reducer should run on the same host that map task ran
@@ -2188,7 +2194,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     submit(reduceRdd, Array(0))
 
     val statuses = (1 to numMapTasks).map { i =>
-      (Success, makeMapStatus("host" + i, 1, (10*i).toByte))
+      (Success, makeMapTaskResult("host" + i, 1, (10*i).toByte))
     }
     complete(taskSets(0), statuses)
 
@@ -2212,8 +2218,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     val reduceRdd = new MyRDD(sc, 1, List(shuffleDep, narrowDep), tracker = mapOutputTracker)
     submit(reduceRdd, Array(0))
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 1))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostA", 1))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostA")))
 
     // Reducer should run where RDD 2 has preferences, even though it also has a shuffle dep
@@ -2247,7 +2253,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     submit(rdd1, Array(0))
     intercept[Exception] {
       complete(taskSets(0), Seq(
-        (null, makeMapStatus("hostA", 1))))
+        (null, makeMapTaskResult("hostA", 1))))
     }
   }
 
@@ -2316,8 +2322,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Submit a map stage by itself
     submitMapStage(shuffleDep)
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", reduceRdd.partitions.length)),
-      (Success, makeMapStatus("hostB", reduceRdd.partitions.length))))
+      (Success, makeMapTaskResult("hostA", reduceRdd.partitions.length)),
+      (Success, makeMapTaskResult("hostB", reduceRdd.partitions.length))))
     assert(results.size === 1)
     results.clear()
     assertDataStructuresEmpty()
@@ -2330,7 +2336,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Ask the scheduler to try it again; TaskSet 2 will rerun the map task that we couldn't fetch
     // from, then TaskSet 3 will run the reduce stage
     scheduler.resubmitFailedStages()
-    complete(taskSets(2), Seq((Success, makeMapStatus("hostA", reduceRdd.partitions.length))))
+    complete(taskSets(2), Seq((Success, makeMapTaskResult("hostA", reduceRdd.partitions.length))))
     complete(taskSets(3), Seq((Success, 43)))
     assert(results === Map(0 -> 42, 1 -> 43))
     results.clear()
@@ -2375,16 +2381,16 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Complete the first stage
     assert(taskSets(0).stageId === 0)
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", rdd1.partitions.length)),
-      (Success, makeMapStatus("hostB", rdd1.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostA", rdd1.partitions.length)),
+      (Success, makeMapTaskResult("hostB", rdd1.partitions.length))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
     assert(listener1.results.size === 1)
 
     // When attempting the second stage, show a fetch failure
     assert(taskSets(1).stageId === 1)
     complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostA", rdd2.partitions.length)),
+      (Success, makeMapTaskResult("hostA", rdd2.partitions.length)),
       (FetchFailed(makeBlockManagerId("hostA"), dep1.shuffleId, 0L, 0, 0, "ignored"), null)))
     scheduler.resubmitFailedStages()
     assert(listener2.results.size === 0)    // Second stage listener should not have a result yet
@@ -2392,17 +2398,17 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Stage 0 should now be running as task set 2; make its task succeed
     assert(taskSets(2).stageId === 0)
     complete(taskSets(2), Seq(
-      (Success, makeMapStatus("hostC", rdd2.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostC", rdd2.partitions.length))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostC"), makeBlockManagerId("hostB")))
     assert(listener2.results.size === 0)    // Second stage listener should still not have a result
 
     // Stage 1 should now be running as task set 3; make its first task succeed
     assert(taskSets(3).stageId === 1)
     complete(taskSets(3), Seq(
-      (Success, makeMapStatus("hostB", rdd2.partitions.length)),
-      (Success, makeMapStatus("hostD", rdd2.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep2.shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostB", rdd2.partitions.length)),
+      (Success, makeMapTaskResult("hostD", rdd2.partitions.length))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(dep2.shuffleId, 0).blocks.map(_._1).toSet ===
       HashSet(makeBlockManagerId("hostB"), makeBlockManagerId("hostD")))
     assert(listener2.results.size === 1)
 
@@ -2417,7 +2423,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // TaskSet 5 will rerun stage 1's lost task, then TaskSet 6 will rerun stage 2
     assert(taskSets(5).stageId === 1)
     complete(taskSets(5), Seq(
-      (Success, makeMapStatus("hostE", rdd2.partitions.length))))
+      (Success, makeMapTaskResult("hostE", rdd2.partitions.length))))
     complete(taskSets(6), Seq(
       (Success, 53)))
     assert(listener3.results === Map(0 -> 52, 1 -> 53))
@@ -2439,16 +2445,16 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Complete the stage0.
     assert(taskSets(0).stageId === 0)
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", rdd1.partitions.length)),
-      (Success, makeMapStatus("hostB", rdd1.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostA", rdd1.partitions.length)),
+      (Success, makeMapTaskResult("hostB", rdd1.partitions.length))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).blocks.map(_._1).toSet ===
         HashSet(makeBlockManagerId("hostA"), makeBlockManagerId("hostB")))
     assert(listener1.results.size === 1)
 
     // When attempting stage1, trigger a fetch failure.
     assert(taskSets(1).stageId === 1)
     complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostC", rdd2.partitions.length)),
+      (Success, makeMapTaskResult("hostC", rdd2.partitions.length)),
       (FetchFailed(makeBlockManagerId("hostA"), dep1.shuffleId, 0L, 0, 0, "ignored"), null)))
     scheduler.resubmitFailedStages()
     // Stage1 listener should not have a result yet
@@ -2458,7 +2464,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     runEvent(makeCompletionEvent(
       taskSets(1).tasks(1),
       Success,
-      makeMapStatus("hostD", rdd2.partitions.length)))
+      makeMapTaskResult("hostD", rdd2.partitions.length)))
     // stage1 listener still should not have a result, though there's no missing partitions
     // in it. Because stage1 has been failed and is not inside `runningStages` at this moment.
     assert(listener2.results.size === 0)
@@ -2466,8 +2472,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Stage0 should now be running as task set 2; make its task succeed
     assert(taskSets(2).stageId === 0)
     complete(taskSets(2), Seq(
-      (Success, makeMapStatus("hostC", rdd2.partitions.length))))
-    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).map(_._1).toSet ===
+      (Success, makeMapTaskResult("hostC", rdd2.partitions.length))))
+    assert(mapOutputTracker.getMapSizesByExecutorId(dep1.shuffleId, 0).blocks.map(_._1).toSet ===
         Set(makeBlockManagerId("hostC"), makeBlockManagerId("hostB")))
 
     // After stage0 is finished, stage1 will be submitted and found there is no missing
@@ -2493,7 +2499,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     submitMapStage(shuffleDep)
 
     val oldTaskSet = taskSets(0)
-    runEvent(makeCompletionEvent(oldTaskSet.tasks(0), Success, makeMapStatus("hostA", 2)))
+    runEvent(makeCompletionEvent(oldTaskSet.tasks(0), Success, makeMapTaskResult("hostA", 2)))
     assert(results.size === 0)    // Map stage job should not be complete yet
 
     // Pretend host A was lost. This will cause the TaskSetManager to resubmit task 0, because it
@@ -2504,11 +2510,11 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(newEpoch > oldEpoch)
 
     // Suppose we also get a completed event from task 1 on the same host; this should be ignored
-    runEvent(makeCompletionEvent(oldTaskSet.tasks(1), Success, makeMapStatus("hostA", 2)))
+    runEvent(makeCompletionEvent(oldTaskSet.tasks(1), Success, makeMapTaskResult("hostA", 2)))
     assert(results.size === 0)    // Map stage job should not be complete yet
 
     // A completion from another task should work because it's a non-failed host
-    runEvent(makeCompletionEvent(oldTaskSet.tasks(2), Success, makeMapStatus("hostB", 2)))
+    runEvent(makeCompletionEvent(oldTaskSet.tasks(2), Success, makeMapTaskResult("hostB", 2)))
 
     // At this point, no more tasks are running for the stage (and the TaskSetManager considers
     // the stage complete), but the task that ran on hostA needs to be re-run, so the map stage
@@ -2523,13 +2529,13 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Complete task 0 from the original task set (i.e., not hte one that's currently active).
     // This should still be counted towards the job being complete (but there's still one
     // outstanding task).
-    runEvent(makeCompletionEvent(newTaskSet.tasks(0), Success, makeMapStatus("hostB", 2)))
+    runEvent(makeCompletionEvent(newTaskSet.tasks(0), Success, makeMapTaskResult("hostB", 2)))
     assert(results.size === 0)
 
     // Complete the final task, from the currently active task set.  There's still one
     // running task, task 0 in the currently active stage attempt, but the success of task 0 means
     // the DAGScheduler can mark the stage as finished.
-    runEvent(makeCompletionEvent(newTaskSet.tasks(1), Success, makeMapStatus("hostB", 2)))
+    runEvent(makeCompletionEvent(newTaskSet.tasks(1), Success, makeMapTaskResult("hostB", 2)))
     assert(results.size === 1)    // Map stage job should now finally be complete
     assertDataStructuresEmpty()
 
@@ -2643,8 +2649,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     // Complete both tasks in rddA.
     assert(taskSets(0).stageId === 0 && taskSets(0).stageAttemptId === 0)
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostA", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostA", 2))))
 
     // Fetch failed for task(stageId=1, stageAttemptId=0, partitionId=0) running on hostA
     // and task(stageId=1, stageAttemptId=0, partitionId=1) is still running.
@@ -2661,14 +2667,14 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(taskSets(2).stageId === 0 && taskSets(2).stageAttemptId === 1
       && taskSets(2).tasks.size === 2)
     complete(taskSets(2), Seq(
-      (Success, makeMapStatus("hostB", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostB", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
 
     // Complete task(stageId=1, stageAttemptId=0, partitionId=1) running on failed hostA
     // successfully. The success should be ignored because the task started before the
     // executor failed, so the output may have been lost.
     runEvent(makeCompletionEvent(
-      taskSets(1).tasks(1), Success, makeMapStatus("hostA", 2)))
+      taskSets(1).tasks(1), Success, makeMapTaskResult("hostA", 2)))
 
     // task(stageId=1, stageAttemptId=1, partitionId=1) should be marked completed when
     // task(stageId=1, stageAttemptId=0, partitionId=1) finished
@@ -2681,7 +2687,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
     assert(taskSets(3).stageId === 1 && taskSets(3).stageAttemptId === 1
       && taskSets(3).tasks.size === 2)
     runEvent(makeCompletionEvent(
-      taskSets(3).tasks(0), Success, makeMapStatus("hostB", 2)))
+      taskSets(3).tasks(0), Success, makeMapTaskResult("hostB", 2)))
 
     // At this point there should be no active task set for stageId=1 and we need
     // to resubmit because the output from (stageId=1, stageAttemptId=0, partitionId=1)
@@ -2692,7 +2698,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Complete task(stageId=1, stageAttempt=2, partitionId=1) successfully.
     runEvent(makeCompletionEvent(
-      taskSets(4).tasks(0), Success, makeMapStatus("hostB", 2)))
+      taskSets(4).tasks(0), Success, makeMapTaskResult("hostB", 2)))
 
     // Now the ResultStage should be submitted, because all of the tasks of rddB have
     // completed successfully on alive executors.
@@ -2819,14 +2825,14 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Finish the first shuffle map stage.
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId1) === Some(Seq.empty))
 
     // Finish the second shuffle map stage.
     complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostC", 2)),
-      (Success, makeMapStatus("hostD", 2))))
+      (Success, makeMapTaskResult("hostC", 2)),
+      (Success, makeMapTaskResult("hostD", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId2) === Some(Seq.empty))
 
     // The first task of the final stage failed with fetch failure
@@ -2886,13 +2892,13 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Finish all stage.
     complete(taskSets(4), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId1) === Some(Seq.empty))
 
     complete(taskSets(5), Seq(
-      (Success, makeMapStatus("hostC", 2)),
-      (Success, makeMapStatus("hostD", 2))))
+      (Success, makeMapTaskResult("hostC", 2)),
+      (Success, makeMapTaskResult("hostD", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId2) === Some(Seq.empty))
 
     complete(taskSets(6), Seq((Success, 11), (Success, 12)))
@@ -2924,13 +2930,13 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Finish the first 2 shuffle map stages.
     complete(taskSets(0), Seq(
-      (Success, makeMapStatus("hostA", 2)),
-      (Success, makeMapStatus("hostB", 2))))
+      (Success, makeMapTaskResult("hostA", 2)),
+      (Success, makeMapTaskResult("hostB", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId1) === Some(Seq.empty))
 
     complete(taskSets(1), Seq(
-      (Success, makeMapStatus("hostB", 2)),
-      (Success, makeMapStatus("hostD", 2))))
+      (Success, makeMapTaskResult("hostB", 2)),
+      (Success, makeMapTaskResult("hostD", 2))))
     assert(mapOutputTracker.findMissingPartitions(shuffleId2) === Some(Seq.empty))
 
     // Executor lost on hostB, both of stage 0 and 1 should be reran.
@@ -2951,8 +2957,8 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
       assert(taskSets(taskSetIndex).stageAttemptId == 1)
       assert(taskSets(taskSetIndex).tasks.length == 2)
       complete(taskSets(taskSetIndex), Seq(
-        (Success, makeMapStatus("hostA", 2)),
-        (Success, makeMapStatus("hostB", 2))))
+        (Success, makeMapTaskResult("hostA", 2)),
+        (Success, makeMapTaskResult("hostB", 2))))
       assert(mapOutputTracker.findMissingPartitions(shuffleId) === Some(Seq.empty))
     }
 
@@ -3098,7 +3104,7 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Finish the first task of the shuffle map stage.
     runEvent(makeCompletionEvent(
-      taskSets(0).tasks(0), Success, makeMapStatus("hostA", 4),
+      taskSets(0).tasks(0), Success, makeMapTaskResult("hostA", 4),
       Seq.empty, Array.empty, createFakeTaskInfoWithId(0)))
 
     // The second task of the shuffle map stage failed with FetchFailed.
@@ -3114,19 +3120,19 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 
     // Finish the first task of the second attempt of the shuffle map stage.
     runEvent(makeCompletionEvent(
-      taskSets(1).tasks(0), Success, makeMapStatus("hostA", 4),
+      taskSets(1).tasks(0), Success, makeMapTaskResult("hostA", 4),
       Seq.empty, Array.empty, createFakeTaskInfoWithId(0)))
 
     // Finish the third task of the first attempt of the shuffle map stage.
     runEvent(makeCompletionEvent(
-      taskSets(0).tasks(2), Success, makeMapStatus("hostA", 4),
+      taskSets(0).tasks(2), Success, makeMapTaskResult("hostA", 4),
       Seq.empty, Array.empty, createFakeTaskInfoWithId(0)))
     assert(tasksMarkedAsCompleted.length == 1)
     assert(tasksMarkedAsCompleted.head.partitionId == 2)
 
     // Finish the forth task of the first attempt of the shuffle map stage.
     runEvent(makeCompletionEvent(
-      taskSets(0).tasks(3), Success, makeMapStatus("hostA", 4),
+      taskSets(0).tasks(3), Success, makeMapTaskResult("hostA", 4),
       Seq.empty, Array.empty, createFakeTaskInfoWithId(0)))
     assert(tasksMarkedAsCompleted.length == 2)
     assert(tasksMarkedAsCompleted.last.partitionId == 3)
@@ -3194,8 +3200,12 @@ class DAGSchedulerSuite extends SparkFunSuite with LocalSparkContext with TimeLi
 }
 
 object DAGSchedulerSuite {
-  def makeMapStatus(host: String, reduces: Int, sizes: Byte = 2, mapTaskId: Long = -1): MapStatus =
-    MapStatus(makeBlockManagerId(host), Array.fill[Long](reduces)(sizes), mapTaskId)
+  def makeMapTaskResult(host: String, reduces: Int, sizes: Byte = 2, mapTaskId: Long = -1)
+    : MapTaskResult = {
+    MapTaskResult(
+      MapStatus(makeBlockManagerId(host), Array.fill[Long](reduces)(sizes), mapTaskId),
+      None)
+  }
 
   def makeBlockManagerId(host: String): BlockManagerId =
     BlockManagerId("exec-" + host, host, 12345)

--- a/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala
+++ b/core/src/test/scala/org/apache/spark/scheduler/SchedulerIntegrationSuite.scala
@@ -196,7 +196,7 @@ abstract class SchedulerIntegrationSuite[T <: MockBackend: ClassTag] extends Spa
       // really we should have already thrown an exception rather than fail either of these
       // asserts, but just to be extra defensive let's double check the statuses are OK
       assert(statuses != null)
-      assert(statuses.nonEmpty)
+      assert(statuses.blocks.nonEmpty)
     }
   }
 
@@ -584,7 +584,7 @@ class BasicSchedulerIntegrationSuite extends SchedulerIntegrationSuite[SingleCor
           val shuffleId =
             scheduler.stageIdToStage(stage).asInstanceOf[ShuffleMapStage].shuffleDep.shuffleId
           backend.taskSuccess(taskDescription,
-            DAGSchedulerSuite.makeMapStatus("hostA", shuffleIdToOutputParts(shuffleId)))
+            DAGSchedulerSuite.makeMapTaskResult("hostA", shuffleIdToOutputParts(shuffleId)))
         case (4, 0, partition) =>
           backend.taskSuccess(taskDescription, 4321 + partition)
       }
@@ -619,7 +619,7 @@ class BasicSchedulerIntegrationSuite extends SchedulerIntegrationSuite[SingleCor
 
       (task.stageId, task.stageAttemptId, task.partitionId) match {
         case (0, _, _) =>
-          backend.taskSuccess(taskDescription, DAGSchedulerSuite.makeMapStatus("hostA", 10))
+          backend.taskSuccess(taskDescription, DAGSchedulerSuite.makeMapTaskResult("hostA", 10))
         case (1, 0, 0) =>
           val fetchFailed = FetchFailed(
             DAGSchedulerSuite.makeBlockManagerId("hostA"), shuffleId, 0L, 0, 0, "ignored")

--- a/core/src/test/scala/org/apache/spark/shuffle/ShuffleDriverComponentsSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/ShuffleDriverComponentsSuite.scala
@@ -17,16 +17,18 @@
 
 package org.apache.spark.shuffle
 
-import java.util.{Map => JMap}
+import java.util.{Map => JMap, Optional => JOptional}
 import java.util.concurrent.atomic.AtomicBoolean
 
 import com.google.common.collect.ImmutableMap
 import org.scalatest.Assertions._
 import org.scalatest.BeforeAndAfterEach
 
-import org.apache.spark.{LocalSparkContext, SparkConf, SparkContext, SparkFunSuite}
+import org.apache.spark.{LocalSparkContext, ShuffleDependency, SparkConf, SparkContext, SparkFunSuite}
 import org.apache.spark.internal.config.SHUFFLE_IO_PLUGIN_CLASS
 import org.apache.spark.shuffle.api.{ShuffleDataIO, ShuffleDriverComponents, ShuffleExecutorComponents, ShuffleMapOutputWriter}
+import org.apache.spark.shuffle.api.io.ShuffleBlockInputStream
+import org.apache.spark.shuffle.api.metadata.{ShuffleBlockInfo, ShuffleMetadata}
 import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO
 
 class ShuffleDriverComponentsSuite
@@ -91,5 +93,22 @@ class TestShuffleExecutorComponentsInitialized(delegate: ShuffleExecutorComponen
       mapTaskId: Long,
       numPartitions: Int): ShuffleMapOutputWriter = {
     delegate.createMapOutputWriter(shuffleId, mapTaskId, numPartitions)
+  }
+
+  override def getPartitionReaders[K, V, C](
+    blockInfos: java.lang.Iterable[ShuffleBlockInfo],
+    dependency: ShuffleDependency[K, V, C],
+    shuffleMetadata: JOptional[ShuffleMetadata]): java.lang.Iterable[ShuffleBlockInputStream] = {
+    delegate.getPartitionReaders(blockInfos, dependency, shuffleMetadata)
+  }
+
+  override def getPartitionReadersForRange[K, V, C](
+      blockInfos: java.lang.Iterable[ShuffleBlockInfo],
+      startPartition: Int,
+      endPartition: Int,
+      dependency: ShuffleDependency[K, V, C],
+      shuffleMetadata: JOptional[ShuffleMetadata]): java.lang.Iterable[ShuffleBlockInputStream] = {
+    delegate.getPartitionReadersForRange(
+      blockInfos, startPartition, endPartition, dependency, shuffleMetadata)
   }
 }

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupMapOutputMetadata.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupMapOutputMetadata.scala
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import org.apache.spark.shuffle.api.metadata.MapOutputMetadata
+
+case class MockAsyncBackupMapOutputMetadata(
+    backupIdsByPartition: Map[Int, String],
+    delegateMetadata: Option[MapOutputMetadata])
+  extends MapOutputMetadata

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupMapOutputWriter.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupMapOutputWriter.scala
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import java.io.{ByteArrayOutputStream, FilterOutputStream, OutputStream}
+import java.nio.file.{Files, Path}
+
+import scala.collection.mutable
+import scala.compat.java8.OptionConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
+
+import org.apache.spark.shuffle.api.{ShuffleMapOutputWriter, ShufflePartitionWriter}
+import org.apache.spark.shuffle.api.metadata.MapOutputCommitMessage
+
+class MockAsyncBackupMapOutputWriter(
+    shuffleBackupManager: MockAsyncShuffleBlockBackupManager,
+    localDelegate: ShuffleMapOutputWriter,
+    shuffleId: Int,
+    mapId: Long,
+    private implicit val backupExecutionContext: ExecutionContext)
+  extends ShuffleMapOutputWriter {
+
+  private var backupTasks: mutable.Set[Future[Path]] = mutable.Set[Future[Path]]()
+  private val backupIdsByPartition: mutable.Map[Int, String] = mutable.Map[Int, String]()
+
+  override def getPartitionWriter(reducePartitionId: Int): ShufflePartitionWriter = {
+    localDelegate.getPartitionWriter(reducePartitionId)
+  }
+
+  override def commitAllPartitions(): MapOutputCommitMessage = {
+    val delegateMessage = localDelegate.commitAllPartitions()
+    val metadata = MockAsyncBackupMapOutputMetadata(
+      backupIdsByPartition.toMap,
+      delegateMessage.getMapOutputMetadata.asScala)
+    MapOutputCommitMessage.of(delegateMessage.getPartitionLengths, metadata)
+  }
+
+  override def abort(error: Throwable): Unit = {
+    localDelegate.abort(error)
+    backupTasks.foreach { task =>
+      task.onComplete {
+        case Success(path) => Files.delete(path)
+      }
+    }
+    shuffleBackupManager.deleteShufflesWithBackupIds(shuffleId, backupIdsByPartition.values.toSet)
+  }
+
+  private class MockAsyncBackupShufflePartitionWriter(reducePartitionId: Int)
+      extends ShufflePartitionWriter {
+    private val localDelegatePartWriter = localDelegate.getPartitionWriter(reducePartitionId)
+    private val partBytesInMemoryOutput = new ByteArrayOutputStream()
+
+    override def openStream(): OutputStream = {
+      new FilterOutputStream(localDelegatePartWriter.openStream()) {
+
+        override def write(b: Int): Unit = {
+          super.write(b)
+          partBytesInMemoryOutput.write(b)
+        }
+
+        override def write(b: Array[Byte], off: Int, len: Int): Unit = {
+          super.write(b, off, len)
+          partBytesInMemoryOutput.write(b, off, len)
+        }
+
+        override def close(): Unit = {
+          super.close()
+          val (backupId, task) = shuffleBackupManager.backupBlock(
+            shuffleId, mapId, reducePartitionId, partBytesInMemoryOutput.toByteArray)
+          backupTasks += task
+          backupIdsByPartition(reducePartitionId) = backupId
+        }
+      }
+    }
+
+    override def getNumBytesWritten: Long = localDelegatePartWriter.getNumBytesWritten
+  }
+}

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleDataIO.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleDataIO.scala
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import org.apache.spark.SparkConf
+import org.apache.spark.shuffle.api.{ShuffleDataIO, ShuffleDriverComponents, ShuffleExecutorComponents}
+import org.apache.spark.shuffle.sort.io.LocalDiskShuffleDataIO
+
+class MockAsyncBackupShuffleDataIO(sparkConf: SparkConf) extends ShuffleDataIO {
+
+  // Can't use Utils.isLocal cause that won't allow for local-cluster - which is allowed here.
+  private val master = sparkConf.get("spark.master")
+  require(master.startsWith("local"), "Master must be in local mode, got: $master")
+
+  private val localDelegate: LocalDiskShuffleDataIO = new LocalDiskShuffleDataIO(sparkConf)
+
+  override def executor(): ShuffleExecutorComponents = {
+    new MockAsyncBackupShuffleExecutorComponents(localDelegate.executor())
+  }
+
+  override def driver(): ShuffleDriverComponents = {
+    new MockAsyncBackupShuffleDriverComponents(localDelegate.driver())
+  }
+}
+
+object MockAsyncBackupShuffleDataIO {
+  val BACKUP_DIR = "spark.shuffle.storage.test.backup.dir"
+}

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleDriverComponents.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleDriverComponents.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import java.io.File
+import java.util
+
+import scala.collection.JavaConverters._
+import scala.compat.java8.OptionConverters._
+import scala.concurrent.ExecutionContext
+
+import org.apache.spark.shuffle.api.ShuffleDriverComponents
+import org.apache.spark.shuffle.api.metadata.ShuffleOutputTracker
+import org.apache.spark.util.{ThreadUtils, Utils}
+
+class MockAsyncBackupShuffleDriverComponents(
+    localDelegate: ShuffleDriverComponents) extends ShuffleDriverComponents {
+
+  private var backupManager: MockAsyncShuffleBlockBackupManager = _
+  private var backupDir: File = _
+  private var tracker: ShuffleOutputTracker = _
+
+  override def initializeApplication(): util.Map[String, String] = {
+    val delegateConfs = localDelegate.initializeApplication().asScala
+    backupDir = Utils.createTempDir(namePrefix = "test-shuffle-backups")
+    backupManager = new MockAsyncShuffleBlockBackupManager(
+      backupDir,
+      ExecutionContext.fromExecutorService(ThreadUtils.newDaemonSingleThreadExecutor(
+        "driver-test-shuffle-backups")))
+    tracker = new MockAsyncBackupShuffleOutputTracker(
+      backupManager, localDelegate.shuffleOutputTracker().asScala)
+    (delegateConfs ++
+      Map[String, String](MockAsyncBackupShuffleDataIO.BACKUP_DIR -> backupDir.getAbsolutePath))
+      .asJava
+  }
+
+  override def cleanupApplication(): Unit = {
+    localDelegate.cleanupApplication()
+    if (backupDir != null) {
+      Utils.deleteRecursively(backupDir)
+    }
+  }
+
+  override def shuffleOutputTracker(): java.util.Optional[ShuffleOutputTracker] = {
+    Some(tracker).asJava
+  }
+}

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleExecutorComponents.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleExecutorComponents.scala
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import java.io.File
+import java.nio.file.Files
+import java.util
+
+import scala.concurrent.ExecutionContext
+
+import org.apache.spark.shuffle.api.{ShuffleExecutorComponents, ShuffleMapOutputWriter}
+import org.apache.spark.util.ThreadUtils
+
+class MockAsyncBackupShuffleExecutorComponents(
+      localDelegate: ShuffleExecutorComponents) extends ShuffleExecutorComponents {
+
+  private var backupExecutionContext: ExecutionContext = _
+  private var backupManager: MockAsyncShuffleBlockBackupManager = _
+
+  override def initializeExecutor(
+      appId: String, execId: String, extraConfigs: util.Map[String, String]): Unit = {
+    localDelegate.initializeExecutor(appId, execId, extraConfigs)
+    val backupDirPath = extraConfigs.get(MockAsyncBackupShuffleDataIO.BACKUP_DIR)
+    require(backupDirPath != null,
+      s"Backup path must be specified with ${MockAsyncBackupShuffleDataIO.BACKUP_DIR}")
+    val backupDir = new File(backupDirPath)
+    Files.createDirectories(backupDir.toPath)
+    val backupExecutor = ThreadUtils.newDaemonSingleThreadExecutor("test-shuffle-backups")
+    backupExecutionContext = ExecutionContext.fromExecutorService(backupExecutor)
+    backupManager = new MockAsyncShuffleBlockBackupManager(backupDir, backupExecutionContext)
+  }
+
+  override def createMapOutputWriter(shuffleId: Int, mapTaskId: Long, numPartitions: Int)
+      : ShuffleMapOutputWriter = {
+    val delegateWriter = localDelegate.createMapOutputWriter(shuffleId, mapTaskId, numPartitions)
+    new MockAsyncBackupMapOutputWriter(
+      backupManager,
+      delegateWriter,
+      shuffleId,
+      mapTaskId,
+      backupExecutionContext)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleOutputTracker.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncBackupShuffleOutputTracker.scala
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.collection.JavaConverters._
+
+import org.apache.spark.shuffle.api.metadata.{MapOutputMetadata, ShuffleOutputTracker}
+import org.apache.spark.storage.ShuffleBlockId
+
+class MockAsyncBackupShuffleOutputTracker(
+    backupManager: MockAsyncShuffleBlockBackupManager,
+    localDelegateTracker: Option[ShuffleOutputTracker]) extends ShuffleOutputTracker {
+
+  private val backupIdsByBlockId = new ConcurrentHashMap[ShuffleBlockId, String].asScala
+
+  override def registerShuffle(shuffleId: Int): Unit = {
+    localDelegateTracker.foreach(_.registerShuffle(shuffleId))
+  }
+
+  override def unregisterShuffle(shuffleId: Int, blocking: Boolean): Unit = {
+    localDelegateTracker.foreach(_.unregisterShuffle(shuffleId, blocking))
+    backupManager.deleteAllShufflesWithShuffleId(shuffleId)
+  }
+
+  override def registerMapOutput(
+      shuffleId: Int,
+      mapId: Int,
+      mapTaskAttemptId: Long,
+      mapOutputMetadata: MapOutputMetadata): Unit = {
+    val mockMapOutputMetadata = cast(mapOutputMetadata)
+    localDelegateTracker.foreach { tracker =>
+      mockMapOutputMetadata.delegateMetadata.foreach { metadata =>
+        tracker.registerMapOutput(shuffleId, mapId, mapTaskAttemptId, metadata)
+      }
+    }
+    mockMapOutputMetadata
+      .backupIdsByPartition
+      .foreach { case (partitionId, backupId) =>
+        backupIdsByBlockId(ShuffleBlockId(shuffleId, mapTaskAttemptId, partitionId)) = backupId
+      }
+  }
+
+  override def removeMapOutput(shuffleId: Int, mapId: Int, mapTaskAttemptId: Long): Unit = {
+    localDelegateTracker.foreach(_.removeMapOutput(shuffleId, mapId, mapTaskAttemptId))
+    backupManager.deleteShufflesWithBackupIds(
+      shuffleId,
+      backupIdsByBlockId
+        .filterKeys(key => key.shuffleId == shuffleId && key.mapId == mapTaskAttemptId)
+        .values
+        .toSet)
+  }
+
+  private def cast(generic: MapOutputMetadata): MockAsyncBackupMapOutputMetadata = {
+    require(generic.isInstanceOf[MockAsyncBackupMapOutputMetadata],
+      s"Received unsupported type of output metadata: ${generic.getClass}")
+    generic.asInstanceOf[MockAsyncBackupMapOutputMetadata]
+  }
+}

--- a/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncShuffleBlockBackupManager.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/io/plugin/MockAsyncShuffleBlockBackupManager.scala
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.io.plugin
+
+import java.io.File
+import java.nio.file.{Files, Path, StandardOpenOption}
+import java.util.UUID
+import java.util.concurrent.{ConcurrentHashMap, ExecutorService}
+import javax.annotation.concurrent.GuardedBy
+
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Success
+
+import org.apache.spark.storage.ShuffleBlockId
+import org.apache.spark.util.Utils
+
+class MockAsyncShuffleBlockBackupManager(
+    backupDir: File,
+    private implicit val backupExecutionContext: ExecutionContext) {
+
+  private val backupTasksLock = new Object
+  @GuardedBy("backupTasksLock")
+  private val backupTasks: mutable.Map[ShuffleBlockId, Future[Path]] =
+    new ConcurrentHashMap[ShuffleBlockId, Future[Path]].asScala
+
+  def backupBlock(
+      shuffleId: Int,
+      mapId: Long,
+      partitionId: Int,
+      block: Array[Byte]): (String, Future[Path]) = {
+    val backupId = UUID.randomUUID.toString
+    val blockId = ShuffleBlockId(shuffleId, mapId, partitionId)
+    backupTasksLock.synchronized {
+      val task = Future[Path] {
+        val partitionFile = shuffleDir(shuffleId).resolve(backupId)
+        Files.write(partitionFile, block, StandardOpenOption.CREATE_NEW)
+        partitionFile
+      }
+      backupTasks(ShuffleBlockId(shuffleId, mapId, partitionId)) = task
+      task.onComplete { _ => backupTasks.remove(blockId) }
+      (backupId, task)
+    }
+  }
+
+  def deleteAllShufflesWithShuffleId(shuffleId: Int): Unit = {
+    backupTasksLock.synchronized {
+      backupTasks.filterKeys(blockId => blockId.shuffleId == shuffleId)
+        .values
+        .foreach { task =>
+          task.onComplete {
+            case Success(file) => Files.delete(file)
+          }
+        }
+      }
+      Utils.deleteRecursively(backupDir.toPath.resolve(shuffleId.toString).toFile)
+  }
+
+  def deleteShufflesWithBackupIds(shuffleId: Int, backupIds: Set[String]): Unit = {
+    backupIds.foreach { backupId =>
+      Files.delete(shuffleDir(shuffleId).resolve(backupId))
+    }
+  }
+
+  def getBlock(shuffleId: Int, backupId: String): Array[Byte] = {
+    Files.readAllBytes(shuffleDir(shuffleId).resolve(backupId))
+  }
+
+  private def shuffleDir(shuffleId: Int): Path = {
+    backupDir.toPath.resolve(shuffleId.toString)
+  }
+}

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -145,7 +145,7 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
 
     writer.write(Iterator.empty)
     writer.stop( /* success = */ true)
-    assert(writer.getPartitionLengths.sum === 0)
+    assert(writer.getMapOutputCommitMessage.getPartitionLengths.sum === 0)
     assert(outputFile.exists())
     assert(outputFile.length() === 0)
     assert(temporaryFilesCreated.isEmpty)
@@ -171,8 +171,9 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
       writer.write(records)
       writer.stop( /* success = */ true)
       assert(temporaryFilesCreated.nonEmpty)
-      assert(writer.getPartitionLengths.sum === outputFile.length())
-      assert(writer.getPartitionLengths.count(_ == 0L) === 4) // should be 4 zero length files
+      assert(writer.getMapOutputCommitMessage.getPartitionLengths.sum === outputFile.length())
+      // should be 4 zero length files
+      assert(writer.getMapOutputCommitMessage.getPartitionLengths.count(_ == 0L) === 4)
       assert(temporaryFilesCreated.count(_.exists()) === 0) // check that temp files were deleted
       val shuffleWriteMetrics = taskContext.taskMetrics().shuffleWriteMetrics
       assert(shuffleWriteMetrics.bytesWritten === outputFile.length())

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/BypassMergeSortShuffleWriterSuite.scala
@@ -118,9 +118,10 @@ class BypassMergeSortShuffleWriterSuite extends SparkFunSuite with BeforeAndAfte
     when(diskBlockManager.getFile(any[BlockId])).thenAnswer { invocation =>
       blockIdToFileMap(invocation.getArguments.head.asInstanceOf[BlockId])
     }
+    val serializerManager = new SerializerManager(new JavaSerializer(conf), conf)
 
     shuffleExecutorComponents = new LocalDiskShuffleExecutorComponents(
-      conf, blockManager, blockResolver)
+      conf, blockManager, serializerManager, blockResolver)
   }
 
   override def afterEach(): Unit = {

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/SortShuffleWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/SortShuffleWriterSuite.scala
@@ -24,7 +24,7 @@ import org.scalatest.Matchers
 
 import org.apache.spark.{Partitioner, SharedSparkContext, ShuffleDependency, SparkFunSuite}
 import org.apache.spark.memory.MemoryTestingUtils
-import org.apache.spark.serializer.JavaSerializer
+import org.apache.spark.serializer.{JavaSerializer, SerializerManager}
 import org.apache.spark.shuffle.{BaseShuffleHandle, IndexShuffleBlockResolver}
 import org.apache.spark.shuffle.api.ShuffleExecutorComponents
 import org.apache.spark.shuffle.sort.io.LocalDiskShuffleExecutorComponents
@@ -43,6 +43,7 @@ class SortShuffleWriterSuite extends SparkFunSuite with SharedSparkContext with 
   private val shuffleBlockResolver = new IndexShuffleBlockResolver(conf)
   private val serializer = new JavaSerializer(conf)
   private var shuffleExecutorComponents: ShuffleExecutorComponents = _
+  private val serializerManager = new SerializerManager(serializer, conf)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -59,8 +60,9 @@ class SortShuffleWriterSuite extends SparkFunSuite with SharedSparkContext with 
       when(dependency.keyOrdering).thenReturn(None)
       new BaseShuffleHandle(shuffleId, dependency)
     }
+
     shuffleExecutorComponents = new LocalDiskShuffleExecutorComponents(
-      conf, blockManager, shuffleBlockResolver)
+      conf, blockManager, serializerManager, shuffleBlockResolver)
   }
 
   override def afterAll(): Unit = {

--- a/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
+++ b/core/src/test/scala/org/apache/spark/shuffle/sort/io/LocalDiskShuffleMapOutputWriterSuite.scala
@@ -136,7 +136,7 @@ class LocalDiskShuffleMapOutputWriterSuite extends SparkFunSuite with BeforeAndA
   }
 
   private def verifyWrittenRecords(): Unit = {
-    val committedLengths = mapOutputWriter.commitAllPartitions()
+    val committedLengths = mapOutputWriter.commitAllPartitions().getPartitionLengths
     assert(partitionSizesInMergedFile === partitionLengths)
     assert(committedLengths === partitionLengths)
     assert(mergedOutputFile.length() === partitionLengths.sum)

--- a/pom.xml
+++ b/pom.xml
@@ -883,6 +883,11 @@
         <version>1.1.2</version>
       </dependency>
       <dependency>
+        <groupId>org.scala-lang.modules</groupId>
+        <artifactId>scala-java8-compat_${scala.binary.version}</artifactId>
+        <version>0.9.1</version>
+      </dependency>
+      <dependency>
         <groupId>jline</groupId>
         <artifactId>jline</artifactId>
         <version>2.14.6</version>


### PR DESCRIPTION
Upstream Spark 3.0 doesn't include complete shuffle I/O plugin support(only the write part). This PR adds full shuffle I/O plugin supports, borrowing the code from https://github.com/mccheah/spark/pulls. 