### PR TITLE
[DNM][oap-native-sql] Columnar AQE enabling. CoalesceShufflePartitions

### DIFF
--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/adaptive/QueryStageExec.scala
@@ -32,6 +32,7 @@ import org.apache.spark.sql.catalyst.plans.physical.Partitioning
 import org.apache.spark.sql.execution._
 import org.apache.spark.sql.execution.exchange._
 import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.vectorized.ColumnarBatch
 import org.apache.spark.util.ThreadUtils
 
 /**
@@ -176,6 +177,10 @@ case class ShuffleQueryStageExec(
     val stats = resultOption.get.asInstanceOf[MapOutputStatistics]
     Option(stats)
   }
+
+  override def supportsColumnar: Boolean = plan.supportsColumnar
+
+  override def doExecuteColumnar(): RDD[ColumnarBatch] = plan.executeColumnar()
 }
 
 /**


### PR DESCRIPTION
### What changes were proposed in this pull request?
When enable AQE, the rules will be only applied on the child of each Exchange operator:

> Exchange
>  |
> child plan   <--  1. apply AQE rules 2. apply columnar rules 3. apply wscg rule

To make ShuffleExchange can be converted to ColumnarShuffleExchange, we need to change it to:

> Exchange  <--  2. apply columnar rules 3. apply wscg rule
>  |
> child plan   <--  1. apply AQE rules



### Does this PR introduce _any_ user-facing change?
No.

### How was this patch tested?
Nativesql tpch is under testing.
