### PR TITLE
[POAE7-655] support concurrent PMem write and records sort

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemWriter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemWriter.java
@@ -17,22 +17,31 @@
 
 package org.apache.spark.util.collection.unsafe.sort;
 
+import org.apache.spark.SparkEnv;
 import org.apache.spark.executor.ShuffleWriteMetrics;
 import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.internal.config.package$;
 import org.apache.spark.serializer.SerializerManager;
 import org.apache.spark.storage.BlockManager;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.array.LongArray;
 import org.apache.spark.unsafe.memory.MemoryBlock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 /**
  * In this writer, records page along with LongArray page are both dumped to PMem when spill happens
  */
 public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
+    private static final Logger logger = LoggerFactory.getLogger(PMemWriter.class);
     private LongArray sortedArray;
     private HashMap<MemoryBlock, MemoryBlock> pageMap = new HashMap<>();
     private int position;
@@ -44,7 +53,8 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
     private int fileBufferSize;
     private boolean isSorted;
     private int totalRecordsWritten;
-
+    private final boolean spillToPMemConcurrently = SparkEnv.get() != null && (boolean) SparkEnv.get().conf().get(
+            package$.MODULE$.MEMORY_SPILL_PMEM_CONCURRENT());
     public PMemWriter(
             UnsafeExternalSorter externalSorter,
             SortedIteratorForSpills sortedIterator,
@@ -75,23 +85,41 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
         // try to allocate all needed PMem pages before spill to PMem
         UnsafeInMemorySorter inMemSorter = externalSorter.getInMemSorter();
         if (allocatePMemPages(allocatedDramPages, inMemSorter.getArray().memoryBlock())) {
-            // TODO: add concurrent sort and write here
-            // write data pages
-            long writeStartTime = System.nanoTime();
-            for (MemoryBlock page : allocatedDramPages) {
-                dumpPageToPMem(page);
-            }
-            taskMetrics.incShuffleSpillWriteTime(System.nanoTime() - writeStartTime);
-            // get sorted iterator
-            if (!isSorted) {
-                long sortStartTime = System.nanoTime();
+            if (spillToPMemConcurrently && !isSorted) {
+                logger.info("Concurrent PMem write/records sort");
+                long writeDuration = 0;
+                ExecutorService executorService = Executors.newSingleThreadExecutor();
+                Future<Long> future = executorService.submit(()->dumpPagesToPMem());
+                long startTime = System.nanoTime();
                 externalSorter.getInMemSorter().getSortedIterator();
-                taskMetrics.incSpillSortTime(System.nanoTime() - sortStartTime);
-                // update LongArray
+                taskMetrics.incSpillSortTime(System.nanoTime() - startTime);
+                try {
+                    writeDuration = future.get();
+                } catch (InterruptedException | ExecutionException e) {
+                    e.printStackTrace();
+                }
+                executorService.shutdownNow();
+                startTime = System.nanoTime();
                 updateLongArray(inMemSorter.getArray(), totalRecordsWritten, 0);
+                taskMetrics.incShuffleSpillWriteTime(writeDuration
+                        + System.nanoTime() - startTime);
+            } else if(!isSorted) {
+                taskMetrics.incShuffleSpillWriteTime(dumpPagesToPMem());
+                // get sorted iterator
+                long startTime = System.nanoTime();
+                externalSorter.getInMemSorter().getSortedIterator();
+                taskMetrics.incSpillSortTime(System.nanoTime() - startTime);
+                // update LongArray
+                startTime = System.nanoTime();
+                updateLongArray(inMemSorter.getArray(), totalRecordsWritten, 0);
+                taskMetrics.incShuffleSpillWriteTime(System.nanoTime() - startTime);
             } else {
+                taskMetrics.incShuffleSpillWriteTime(dumpPagesToPMem());
+                // get sorted iterator
+                long startTime = System.nanoTime();
                 assert(sortedIterator != null);
                 updateLongArray(inMemSorter.getArray(), totalRecordsWritten, sortedIterator.getPosition());
+                taskMetrics.incShuffleSpillWriteTime(System.nanoTime() - startTime);
             }
         } else {
             // fallback to disk spill
@@ -105,7 +133,9 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
                         writeMetrics,
                         taskMetrics);
             }
+            long startTime = System.nanoTime();
             diskSpillWriter.write(false);
+            taskMetrics.incShuffleSpillWriteTime(System.nanoTime() - startTime);
         }
     }
 
@@ -129,6 +159,15 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
             return false;
         }
         return (allocatedPMemPages.size() == dramPages.size() + 1);
+    }
+    private long dumpPagesToPMem() {
+        long dumpTime = System.nanoTime();
+        for (MemoryBlock page : allocatedDramPages) {
+            dumpPageToPMem(page);
+        }
+        long dumpDuration = System.nanoTime() - dumpTime;
+        return dumpDuration;
+
     }
 
     private void dumpPageToPMem(MemoryBlock page) {

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemWriter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemWriter.java
@@ -54,7 +54,7 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
     private boolean isSorted;
     private int totalRecordsWritten;
     private final boolean spillToPMemConcurrently = SparkEnv.get() != null && (boolean) SparkEnv.get().conf().get(
-            package$.MODULE$.MEMORY_SPILL_PMEM_CONCURRENT());
+            package$.MODULE$.MEMORY_SPILL_PMEM_SORT_BACKGROUND());
     public PMemWriter(
             UnsafeExternalSorter externalSorter,
             SortedIteratorForSpills sortedIterator,
@@ -96,7 +96,7 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
                 try {
                     writeDuration = future.get();
                 } catch (InterruptedException | ExecutionException e) {
-                    e.printStackTrace();
+                    logger.error(e.getMessage());
                 }
                 executorService.shutdownNow();
                 startTime = System.nanoTime();
@@ -160,6 +160,7 @@ public final class PMemWriter extends UnsafeSorterPMemSpillWriter {
         }
         return (allocatedPMemPages.size() == dramPages.size() + 1);
     }
+
     private long dumpPagesToPMem() {
         long dumpTime = System.nanoTime();
         for (MemoryBlock page : allocatedDramPages) {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -356,6 +356,12 @@ package object config {
     .checkValue(_ >= 0, "The extended memory size must not be negative")
     .createWithDefault(64 * 1024 * 1024)
 
+  val MEMORY_SPILL_PMEM_CONCURRENT =
+    ConfigBuilder("spark.memory.spill.pmem.concurrent")
+      .doc("Doing sort and dump pages to PMem concurrently")
+      .booleanConf
+      .createWithDefault(false)
+
   val USAFE_EXTERNAL_SORTER_SPILL_WRITE_TYPE = ConfigBuilder("spark.unsafe.sort.spillwriter.type")
     .doc("The spill writer type for UnsafeExteranlSorter")
     .stringConf

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -356,8 +356,8 @@ package object config {
     .checkValue(_ >= 0, "The extended memory size must not be negative")
     .createWithDefault(64 * 1024 * 1024)
 
-  val MEMORY_SPILL_PMEM_CONCURRENT =
-    ConfigBuilder("spark.memory.spill.pmem.concurrent")
+  val MEMORY_SPILL_PMEM_SORT_BACKGROUND =
+    ConfigBuilder("spark.memory.spill.pmem.sort.background")
       .doc("Doing sort and dump pages to PMem concurrently")
       .booleanConf
       .createWithDefault(false)


### PR DESCRIPTION
### Why are the changes needed?
[POAE7-655] support concurrent PMem write and records sort


### Does this PR introduce _any_ user-facing change?
Yes. add configuration option "spark.memory.spill.pmem.concurrent" with default value false


### How was this patch tested?
UT, Q64
