### PR TITLE
[POAE-652] leverage read buffer in PMem read

### DIFF
--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemReaderForUnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemReaderForUnsafeExternalSorter.java
@@ -1,12 +1,20 @@
 package org.apache.spark.util.collection.unsafe.sort;
 
+import org.apache.spark.SparkEnv;
 import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.internal.config.package$;
 import org.apache.spark.unsafe.Platform;
 import org.apache.spark.unsafe.array.LongArray;
+import org.apache.spark.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 
 public final class PMemReaderForUnsafeExternalSorter extends UnsafeSorterIterator implements Closeable {
+    private static final Logger logger = LoggerFactory.getLogger(PMemReaderForUnsafeExternalSorter.class);
     private int recordLength;
     private long keyPrefix;
     private int numRecordsRemaining;
@@ -14,38 +22,93 @@ public final class PMemReaderForUnsafeExternalSorter extends UnsafeSorterIterato
     private LongArray sortedArray;
     private int position;
     private byte[] arr = new byte[1024 * 1024];
+    private byte[] bytes = new byte[1024 * 1024];
     private Object baseObject = arr;
     private TaskMetrics taskMetrics;
     private long startTime;
-    private long address;
+    private ByteBuffer byteBuffer;
     public PMemReaderForUnsafeExternalSorter(
             LongArray sortedArray, int position,  int numRecords, TaskMetrics taskMetrics) {
         this.sortedArray = sortedArray;
         this.position = position;
         this.numRecords = numRecords;
         this.numRecordsRemaining = numRecords - position/2;
-        this.taskMetrics = taskMetrics
-;    }
+        this.taskMetrics = taskMetrics;
+        int readBufferSize = SparkEnv.get() == null? 8 * 1024 * 1024 :
+                (int) SparkEnv.get().conf().get(package$.MODULE$.MEMORY_SPILL_PMEM_READ_BUFFERSIZE());
+        logger.info("PMem read buffer size is:" + Utils.bytesToString(readBufferSize));
+        this.byteBuffer = ByteBuffer.wrap(new byte[readBufferSize]);
+        byteBuffer.flip();
+        byteBuffer.order(ByteOrder.nativeOrder());
+    }
+
     @Override
     public void loadNext() {
-        assert(position < numRecords * 2)
-                : "Illegal state: Pages finished read but hasNext() is true.";
-        address = sortedArray.get(position);
-        keyPrefix = sortedArray.get(position + 1);
         startTime = System.nanoTime();
-        recordLength = Platform.getInt(null, address);
+        if (!byteBuffer.hasRemaining()) {
+            boolean refilled = refill();
+            if (!refilled) {
+                logger.error("Illegal status: records finished read but hasNext() is true.");
+            }
+        }
+        keyPrefix = byteBuffer.getLong();
+        recordLength = byteBuffer.getInt();
         if (recordLength > arr.length) {
             arr = new byte[recordLength];
             baseObject = arr;
         }
-        Platform.copyMemory(null, address + Integer.BYTES , baseObject, Platform.BYTE_ARRAY_OFFSET, recordLength);
+        byteBuffer.get(arr, 0, recordLength);
         taskMetrics.incShuffleSpillReadTime(System.nanoTime() - startTime);
         numRecordsRemaining --;
-        position += 2;
     }
+
     @Override
     public int getNumRecords() {
         return numRecords;
+    }
+
+    /**
+     * load more PMem records in the buffer
+     */
+    private boolean refill() {
+        byteBuffer.clear();
+        int nRead = loadData();
+        byteBuffer.flip();
+        if (nRead <= 0) {
+            return false;
+        }
+        return true;
+    }
+
+    private int loadData() {
+        // no records remaining to read
+        if (position >= numRecords * 2)
+            return -1;
+        int bufferPos = 0;
+        int capacity = byteBuffer.capacity();
+        while (bufferPos < capacity && position < numRecords * 2) {
+            long curRecordAddress = sortedArray.get(position);
+            int recordLen = Platform.getInt(null, curRecordAddress);
+            // length + keyprefix + record length
+            int length = Integer.BYTES + Long.BYTES + recordLen;
+            if (length > capacity) {
+                logger.error("single record size exceeds PMem read buffer. Please increase buffer size.");
+            }
+            if (bufferPos + length <= capacity) {
+                long curKeyPrefix = sortedArray.get(position + 1);
+                if (length > bytes.length) {
+                    bytes = new byte[length];
+                }
+                Platform.putLong(bytes, Platform.BYTE_ARRAY_OFFSET, curKeyPrefix);
+                Platform.copyMemory(null, curRecordAddress, bytes, Platform.BYTE_ARRAY_OFFSET + Long.BYTES, length - Long.BYTES);
+                byteBuffer.put(bytes, 0, length);
+                bufferPos += length;
+                position += 2;
+            } else {
+                break;
+            }
+        }
+        return bufferPos;
     }
 
     @Override

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -341,7 +341,7 @@ package object config {
     ConfigBuilder("spark.memory.spill.pmem.enabled")
       .doc("Set memory spill to PMem instead of disk.")
       .booleanConf
-      .createWithDefault(false)
+      .createWithDefault(true)
 
   val MEMORY_EXTENDED_PATH =
     ConfigBuilder("spark.memory.extended.path")
@@ -372,6 +372,15 @@ package object config {
     .doc("The spill writer type for UnsafeExteranlSorter")
     .stringConf
     .createWithDefault(PMemSpillWriterType.WRITE_SORTED_RECORDS_TO_PMEM.toString())
+
+  private[spark] val MEMORY_SPILL_PMEM_READ_BUFFERSIZE =
+    ConfigBuilder("spark.memory.spill.pmem.readBufferSize")
+      .doc("The buffer size, in bytes, to use when reading records from PMem.")
+      .bytesConf(ByteUnit.BYTE)
+      .checkValue(v => v > 12 && v <= ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH,
+        s"The buffer size must be greater than 12 and less than or equal to " +
+          s"${ByteArrayMethods.MAX_ROUNDED_ARRAY_LENGTH}.")
+      .createWithDefaultString("8m")
 
   private[spark] val MEMORY_STORAGE_FRACTION = ConfigBuilder("spark.memory.storageFraction")
     .doc("Amount of storage memory immune to eviction, expressed as a fraction of the " +

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSpillToPMemSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSpillToPMemSuite.java
@@ -84,7 +84,7 @@ public class UnsafeExternalSorterSpillToPMemSuite {
         serializerManager = new SerializerManager(
                 new JavaSerializer(conf), conf);
         pageSizeBytes =  conf.getSizeAsBytes(
-                package$.MODULE$.BUFFER_PAGESIZE().key(), "4m");
+                package$.MODULE$.BUFFER_PAGESIZE().key(), "1m");
         spillThreshold =
                 (int) conf.get(package$.MODULE$.SHUFFLE_SPILL_NUM_ELEMENTS_FORCE_SPILL_THRESHOLD());
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
add read buffer to support bunch records read for PMem


### Why are the changes needed?
perf optimization


### Does this PR introduce _any_ user-facing change?
configuration spark.memory.spill.pmem.readBufferSize add with default value 8M.


### How was this patch tested?
UT, Q64