### PR TITLE
[POAE7-597] Merge DataIO API implementation with PMemShufflePlugin br…

### DIFF
--- a/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleDataIO.java
+++ b/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleDataIO.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.pmem;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.api.ShuffleDataIO;
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+
+public class PMemShuffleDataIO implements ShuffleDataIO {
+    private final SparkConf sparkConf;
+
+    public PMemShuffleDataIO(SparkConf sparkConf) {
+        this.sparkConf = sparkConf;
+    }
+
+    @Override
+    public ShuffleExecutorComponents executor() {
+        return new PMemShuffleExecutorComponents(sparkConf);
+    }
+
+    @Override
+    public ShuffleDriverComponents driver() {
+        return new PMemShuffleDriverComponets();
+    }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleDriverComponets.java
+++ b/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleDriverComponets.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.pmem;
+
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.shuffle.api.ShuffleDriverComponents;
+import org.apache.spark.storage.BlockManagerMaster;
+
+import java.util.Map;
+import java.util.Collections;
+import java.util.Map;
+
+
+public class PMemShuffleDriverComponets implements ShuffleDriverComponents {
+    private BlockManagerMaster blockManagerMaster;
+
+    @Override
+    public Map<String, String> initializeApplication() {
+        blockManagerMaster = SparkEnv.get().blockManager().master();
+        return Collections.emptyMap();
+    }
+
+    @Override
+    public void cleanupApplication() {
+        // nothing to clean up
+    }
+
+    @Override
+    public void removeShuffle(int shuffleId, boolean blocking) {
+        if (blockManagerMaster == null) {
+            throw new IllegalStateException("Driver components must be initialized before using");
+        }
+        blockManagerMaster.removeShuffle(shuffleId, blocking);
+        //Todo: remove shuffle blocks in pMem.
+    }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleExecutorComponents.java
+++ b/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleExecutorComponents.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.pmem;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.SparkConf;
+import org.apache.spark.storage.BlockManager;
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.spark.shuffle.api.ShuffleExecutorComponents;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.SingleSpillShuffleMapOutputWriter;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class PMemShuffleExecutorComponents implements ShuffleExecutorComponents {
+    private final SparkConf sparkConf;
+    private BlockManager blockManager;
+    private PMemShuffleBlockResolver blockResolver;
+    public PMemShuffleExecutorComponents(SparkConf sparkConf) {
+        this.sparkConf = sparkConf;
+    }
+
+    @VisibleForTesting
+    public PMemShuffleExecutorComponents(
+            SparkConf sparkConf,
+            BlockManager blockManager,
+            PMemShuffleBlockResolver blockResolver
+            ) {
+        this.sparkConf = sparkConf;
+        this.blockManager = blockManager;
+        this.blockResolver = blockResolver;
+    }
+
+    @Override
+    public void initializeExecutor(String appId, String execId, Map<String, String> extraConfigs) {
+        blockManager = SparkEnv.get().blockManager();
+        if (blockManager == null) {
+            throw new IllegalStateException("No blockManager available from the SparkEnv.");
+        }
+        blockResolver = new PMemShuffleBlockResolver(sparkConf, blockManager);
+    }
+
+    @Override
+    public ShuffleMapOutputWriter createMapOutputWriter(
+            int shuffleId,
+            long mapTaskId,
+            int numPartitions) {
+        if (blockResolver == null) {
+            throw new IllegalStateException(
+                    "Executor components must be initialized before getting writers.");
+        }
+        return new PMemShuffleMapOutputWriter(shuffleId, mapTaskId, numPartitions, blockResolver, sparkConf);
+    }
+
+    @Override
+    public Optional<SingleSpillShuffleMapOutputWriter> createSingleFileMapOutputWriter(
+            int shuffleId,
+            long mapId) {
+        return Optional.empty();
+    }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleMapOutputWriter.java
+++ b/core/src/main/java/org/apache/spark/shuffle/pmem/PMemShuffleMapOutputWriter.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.shuffle.pmem;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.apache.spark.SparkConf;
+import org.apache.spark.shuffle.api.ShuffleMapOutputWriter;
+import org.apache.spark.shuffle.api.ShufflePartitionWriter;
+import org.apache.spark.shuffle.api.WritableByteChannelWrapper;
+import org.apache.spark.shuffle.api.metadata.MapOutputCommitMessage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.channels.WritableByteChannel;
+import java.util.Optional;
+
+public class PMemShuffleMapOutputWriter implements ShuffleMapOutputWriter {
+    private static final Logger log =
+            LoggerFactory.getLogger(PMemShuffleMapOutputWriter.class);
+
+    private final int shuffleId;
+    private final long mapId;
+    private final PMemShuffleBlockResolver blockResolver;
+    private final SparkConf conf;
+    private final long[] partitionLengths;
+    private int lastPartitionId = -1;
+
+    public PMemShuffleMapOutputWriter(
+            int shuffleId,
+            long mapId,
+            int numPartitions,
+            PMemShuffleBlockResolver blockResolver,
+            SparkConf sparkConf) {
+        this.shuffleId = shuffleId;
+        this.mapId = mapId;
+        this.blockResolver = blockResolver;
+        this.partitionLengths = new long[numPartitions];
+        this.conf = sparkConf;
+    }
+
+    @Override
+    public ShufflePartitionWriter getPartitionWriter(int reducePartitionId) throws IOException {
+        if (reducePartitionId <= lastPartitionId) {
+            throw new IllegalArgumentException("Partitions should be requested in increasing order.");
+        }
+        lastPartitionId = reducePartitionId;
+        return new PMemShuffleMapOutputWriter.PMemShufflePartitionWriter(reducePartitionId);
+    }
+
+    @Override
+    public MapOutputCommitMessage commitAllPartitions() throws IOException {
+        //Do nothing here, since we don't need write index file here.
+        return null;
+    }
+
+    @Override
+    public void abort(Throwable error) throws IOException {
+      //Do nothing here.
+    }
+
+    private class PMemShufflePartitionWriter implements ShufflePartitionWriter {
+        private final int partitionId;
+        private PMemShuffleMapOutputWriter.PartitionWriterStream partStream = null;
+
+        private PMemShufflePartitionWriter(int partitionId) {
+            this.partitionId = partitionId;
+        }
+
+        @Override
+        public OutputStream openStream() throws IOException {
+            if (partStream == null) {
+                OutputStream chunkOutput = blockResolver.getDataOutputStream(shuffleId, mapId, partitionId);
+                partStream = new PartitionWriterStream(partitionId, chunkOutput);
+            }
+            return partStream;
+        }
+
+        @Override
+        public Optional<WritableByteChannelWrapper> openChannelWrapper() throws IOException {
+            //TODO: will resolve it POAE7-771
+            throw new UnsupportedOperationException("WritableByteChannelWrapper is not implemented for " +
+                    "PMemShufflePartitionWriter");
+        }
+
+        @Override
+        public long getNumBytesWritten() {
+            if (partStream != null) {
+                return partStream.getCount();
+            } else {
+                // Assume an empty partition if stream and channel are never created
+                return 0;
+            }
+        }
+    }
+
+   //TODo: will implement it in POAE7-771.
+    private class PMemShufflePartitionWritableChannel implements WritableByteChannelWrapper {
+
+        @Override
+        public WritableByteChannel channel() {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+    }
+
+    private class PartitionWriterStream extends OutputStream {
+        private final int partitionId;
+        private int count = 0;
+        private boolean isClosed = false;
+        private OutputStream partStream = null;
+
+        PartitionWriterStream(int partitionId,OutputStream partStream) {
+            this.partitionId = partitionId;
+            this.partStream = partStream;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            verifyNotClosed();
+            partStream.write(b);
+            count++;
+        }
+
+        @Override
+        public void write(byte[] buf, int pos, int length) throws IOException {
+            verifyNotClosed();
+            partStream.write(buf, pos, length);
+            count += length;
+        }
+
+        @Override
+        public void close() {
+            isClosed = true;
+            partitionLengths[partitionId] = count;
+        }
+
+        private void verifyNotClosed() {
+            if (isClosed) {
+                throw new IllegalStateException("Attempting to write to a closed block output stream.");
+            }
+        }
+    }
+}

--- a/core/src/main/java/org/apache/spark/shuffle/pmem/PlasmaShuffleUtil.java
+++ b/core/src/main/java/org/apache/spark/shuffle/pmem/PlasmaShuffleUtil.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.shuffle.pmem;
+
+public class PlasmaShuffleUtil {
+    public static String generateShuffleId( int shuffleId, long mapId, int reduceId){
+        return shuffleId + "_" + mapId + "_" + reduceId;
+    }
+}

--- a/core/src/main/scala/org/apache/spark/shuffle/pmem/PlasmaInputSteamManagedBuffer.scala
+++ b/core/src/main/scala/org/apache/spark/shuffle/pmem/PlasmaInputSteamManagedBuffer.scala
@@ -19,19 +19,18 @@ package org.apache.spark.shuffle.pmem
 
 import java.io.InputStream
 import java.io.IOException
+import java.io.SequenceInputStream
 import java.nio.ByteBuffer
 import java.nio.channels.{Channels, ReadableByteChannel, WritableByteChannel}
 import java.util.{ArrayList, Collections, Enumeration, List}
-import java.io.SequenceInputStream
-import java.nio.ByteBuffer
+
+import org.apache.spark.io.pmem.PlasmaInputStream
 import org.apache.spark.network.buffer.ManagedBuffer
 import org.apache.spark.network.util.AbstractFileRegion
 import org.apache.spark.network.util.TransportConf
-import org.apache.spark.storage.BlockId
-import org.apache.spark.io.pmem.PlasmaInputStream
 
-
-private[spark] class PlasmaInputSteamManagedBuffer(transportConf: TransportConf) extends ManagedBuffer {
+private[spark] class PlasmaInputSteamManagedBuffer(transportConf: TransportConf)
+  extends ManagedBuffer {
   private val streams: List[PlasmaInputStream] = new ArrayList[PlasmaInputStream]
   private val curStreamIdx: Int = 0
   private var totalLength: Long = 0L
@@ -41,7 +40,8 @@ private[spark] class PlasmaInputSteamManagedBuffer(transportConf: TransportConf)
   }
 
   override def nioByteBuffer(): ByteBuffer = {
-    //TODO: wait PlasmaInputStream to add getByteBuffer() which returns a DirectByteBuffer
+    // TODO:wait PlasmaInputStream to add getByteBuffer()
+    // which returns a DirectByteBuffer
     null
   }
 


### PR DESCRIPTION
1）WritableByteChannelWrapper for PMemShuffleMapOutputWriter is not implemented yet. Will address it in POAE7-771
2)  Still not integerate DataIO API with sortShuffleManager and blockManager. Will address it in POAE7-772
3)  Will add unit tests in PR for POAE7-771