### PR TITLE
[POAE7-857] Port StreamAPI based memory extension in new framework

### DIFF
--- a/core/src/main/java/org/apache/spark/memory/PMemManagerInitializer.java
+++ b/core/src/main/java/org/apache/spark/memory/PMemManagerInitializer.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.memory;
+
+import com.intel.oap.common.storage.stream.PMemManager;
+
+import org.apache.spark.SparkEnv;
+import org.apache.spark.internal.config.ConfigEntry;
+import org.apache.spark.internal.config.package$;
+import org.apache.spark.util.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedInputStream;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
+public class PMemManagerInitializer {
+    private static final Logger logger = LoggerFactory.getLogger(PMemManagerInitializer.class);
+    private static PMemManager pMemManager;
+    private static Properties properties;
+
+    public static Properties getProperties() {
+        if (properties == null) {
+            synchronized (Properties.class) {
+                if (properties == null) {
+                    ConfigEntry<String> pMemPropertiesFile =
+                            package$.MODULE$.PMEM_PROPERTY_FILE();
+                    String filePath = SparkEnv.get() == null ? pMemPropertiesFile.defaultValue().get() : SparkEnv.get().conf().get(pMemPropertiesFile);
+                    logger.debug("PMem Property file: " + filePath);
+                    Properties pps = new Properties();
+                    InputStream in = null;
+                    try {
+                        in = Utils.getSparkClassLoader().getResourceAsStream(filePath);
+                        if (in == null) {
+                            in = new BufferedInputStream(new FileInputStream(filePath));
+                        }
+                        assert(in != null);
+                        pps.load(in);
+                        pps.setProperty("chunkSize", String.valueOf(
+                                Utils.byteStringAsBytes(pps.getProperty("chunkSize"))));
+                        pps.setProperty("totalSize", String.valueOf(
+                                Utils.byteStringAsBytes(pps.getProperty("totalSize"))));
+                        pps.setProperty("initialSize", String.valueOf(
+                                Utils.byteStringAsBytes(pps.getProperty("initialSize"))));
+                    } catch (IOException e) {
+                        e.printStackTrace();
+                    } finally {
+                        try {
+                            in.close();
+                        } catch (IOException e) {
+                            e.printStackTrace();
+                        }
+                    }
+                    properties = pps;
+                }
+            }
+        }
+        return properties;
+    }
+
+    public static PMemManager getPMemManager() {
+        if (pMemManager == null) {
+            synchronized (PMemManager.class) {
+                if (pMemManager == null) {
+                    pMemManager = new PMemManager(getProperties());
+                }
+            }
+        }
+        return pMemManager;
+    }
+}

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemSpillWriterType.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/PMemSpillWriterType.java
@@ -18,6 +18,7 @@
 package org.apache.spark.util.collection.unsafe.sort;
 
 public enum PMemSpillWriterType {
+    STREAM_SPILL_TO_PMEM,
     MEM_COPY_ALL_DATA_PAGES_TO_PMEM,
     MEM_COPY_ALL_DATA_PAGES_TO_PMEM_WITHLONGARRAY,
     WRITE_SORTED_RECORDS_TO_PMEM

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorter.java
@@ -542,10 +542,12 @@ public final class UnsafeExternalSorter extends MemoryConsumer {
           && numRecords > 0)) {
           return 0L;
         }
+        UnsafeInMemorySorter.SortedIterator inMemIterator =
+                ((UnsafeInMemorySorter.SortedIterator) upstream).clone();
         
         ShuffleWriteMetrics writeMetrics = new ShuffleWriteMetrics();
         long released = 0L;
-        SpillWriterForUnsafeSorter spillWriter = spillWithWriter(upstream, numRecords, writeMetrics, true);
+        SpillWriterForUnsafeSorter spillWriter = spillWithWriter(inMemIterator, numRecords, writeMetrics, true);
         nextUpstream = spillWriter.getSpillReader();
 
         synchronized (UnsafeExternalSorter.this) {

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterSpillReader.java
@@ -36,22 +36,26 @@ import java.io.*;
  * Reads spill files written by {@link UnsafeSorterSpillWriter} (see that class for a description
  * of the file format).
  */
-public final class UnsafeSorterSpillReader extends UnsafeSorterIterator implements Closeable {
+public class UnsafeSorterSpillReader extends UnsafeSorterIterator implements Closeable {
   public static final int MAX_BUFFER_SIZE_BYTES = 16777216; // 16 mb
 
-  private InputStream in;
-  private DataInputStream din;
+  protected InputStream in;
+  protected DataInputStream din;
 
   // Variables that change with every record read:
-  private int recordLength;
-  private long keyPrefix;
-  private int numRecords;
-  private int numRecordsRemaining;
+  protected int recordLength;
+  protected long keyPrefix;
+  protected int numRecords;
+  protected int numRecordsRemaining;
 
-  private byte[] arr = new byte[1024 * 1024];
-  private Object baseObject = arr;
-  private final TaskContext taskContext = TaskContext.get();
-  private final TaskMetrics taskMetrics;
+  protected byte[] arr = new byte[1024 * 1024];
+  protected Object baseObject = arr;
+  protected final TaskContext taskContext = TaskContext.get();
+  protected final TaskMetrics taskMetrics;
+
+  public UnsafeSorterSpillReader(TaskMetrics taskMetrics) {
+    this.taskMetrics = taskMetrics;
+  }
 
   public UnsafeSorterSpillReader(
       SerializerManager serializerManager,

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillReader.java
@@ -26,7 +26,6 @@ public class UnsafeSorterStreamSpillReader extends UnsafeSorterSpillReader {
       File file,
       BlockId blockId) throws IOException {
     super(taskMetrics);
-    System.out.println("getting stream reader");
     final ConfigEntry<Object> bufferSizeConfigEntry =
             package$.MODULE$.UNSAFE_SORTER_SPILL_READER_BUFFER_SIZE();
     // This value must be less than or equal to MAX_BUFFER_SIZE_BYTES. Cast to int is always safe.

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillReader.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillReader.java
@@ -1,0 +1,61 @@
+package org.apache.spark.util.collection.unsafe.sort;
+
+import com.google.common.io.Closeables;
+import com.intel.oap.common.storage.stream.ChunkInputStream;
+import com.intel.oap.common.storage.stream.DataStore;
+import org.apache.spark.SparkEnv;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.internal.config.ConfigEntry;
+import org.apache.spark.internal.config.package$;
+import org.apache.spark.io.ReadAheadInputStream;
+import org.apache.spark.memory.PMemManagerInitializer;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.storage.BlockId;
+
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class UnsafeSorterStreamSpillReader extends UnsafeSorterSpillReader {
+
+  protected final ChunkInputStream chunkInputStream;
+  public UnsafeSorterStreamSpillReader(
+      SerializerManager serializerManager,
+      TaskMetrics taskMetrics,
+      File file,
+      BlockId blockId) throws IOException {
+    super(taskMetrics);
+    System.out.println("getting stream reader");
+    final ConfigEntry<Object> bufferSizeConfigEntry =
+            package$.MODULE$.UNSAFE_SORTER_SPILL_READER_BUFFER_SIZE();
+    // This value must be less than or equal to MAX_BUFFER_SIZE_BYTES. Cast to int is always safe.
+    final int DEFAULT_BUFFER_SIZE_BYTES =
+            ((Long) bufferSizeConfigEntry.defaultValue().get()).intValue();
+    int bufferSizeBytes = SparkEnv.get() == null ? DEFAULT_BUFFER_SIZE_BYTES :
+            ((Long) SparkEnv.get().conf().get(bufferSizeConfigEntry)).intValue();
+    final boolean readAheadEnabled = SparkEnv.get() != null && (boolean)SparkEnv.get().conf().get(
+            package$.MODULE$.UNSAFE_SORTER_SPILL_READ_AHEAD_ENABLED());
+    chunkInputStream =
+            ChunkInputStream.getChunkInputStreamInstance(file.toString(),
+                    new DataStore(PMemManagerInitializer.getPMemManager(),
+                            PMemManagerInitializer.getProperties()));
+    final InputStream bs = chunkInputStream;
+    try {
+        if (readAheadEnabled) {
+            this.in = new ReadAheadInputStream(serializerManager.wrapStream(blockId, bs),
+                    bufferSizeBytes);
+        } else {
+            this.in = serializerManager.wrapStream(blockId, bs);
+        }
+        this.din = new DataInputStream(this.in);
+        long startTime = System.nanoTime();
+        numRecords = numRecordsRemaining = din.readInt();
+        long duration = System.nanoTime() - startTime;
+        this.taskMetrics.incShuffleSpillReadTime(duration);
+    } catch (IOException e) {
+        Closeables.close(bs, /* swallowIOException = */ true);
+        throw e;
+    }
+  }
+}

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillWriter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillWriter.java
@@ -1,0 +1,64 @@
+package org.apache.spark.util.collection.unsafe.sort;
+
+import org.apache.spark.executor.ShuffleWriteMetrics;
+import org.apache.spark.executor.TaskMetrics;
+import org.apache.spark.serializer.DummySerializerInstance;
+import org.apache.spark.serializer.SerializerManager;
+import org.apache.spark.storage.BlockManager;
+import org.apache.spark.storage.TempLocalBlockId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import scala.Tuple2;
+
+import java.io.File;
+import java.io.IOException;
+
+public class UnsafeSorterStreamSpillWriter extends UnsafeSorterSpillWriter {
+  private static final Logger logger = LoggerFactory.getLogger(UnsafeSorterStreamSpillWriter.class);
+  private UnsafeSorterStreamSpillReader reader;
+  public UnsafeSorterStreamSpillWriter(
+      BlockManager blockManager,
+      int fileBufferSize,
+      UnsafeSorterIterator inMemIterator,
+      int numRecordsToWrite,
+      SerializerManager serializerManager,
+      ShuffleWriteMetrics writeMetrics,
+      TaskMetrics taskMetrics) {
+    super();
+    System.out.println("getting stream writer");
+    final Tuple2<TempLocalBlockId, File> spilledFileInfo =
+            blockManager.diskBlockManager().createTempLocalBlock();
+    this.file = spilledFileInfo._2();
+    this.blockId = spilledFileInfo._1();
+    this.numRecordsToWrite = numRecordsToWrite;
+    this.serializerManager = serializerManager;
+    this.taskMetrics = taskMetrics;
+    this.inMemIterator = inMemIterator;
+    // Unfortunately, we need a serializer instance in order to construct a DiskBlockObjectWriter.
+    // Our write path doesn't actually use this serializer (since we end up calling the `write()`
+    // OutputStream methods), but DiskBlockObjectWriter still calls some methods on it. To work
+    // around this, we pass a dummy no-op serializer.
+    writer = blockManager.getPMemWriter(
+            blockId, file, DummySerializerInstance.INSTANCE, fileBufferSize, writeMetrics);
+    // Write the number of records
+    writeIntToBuffer(numRecordsToWrite, 0);
+    writer.write(writeBuffer, 0, 4);
+  }
+
+  @Override
+  public UnsafeSorterIterator getSpillReader() throws IOException {
+    reader = new UnsafeSorterStreamSpillReader(serializerManager, taskMetrics, file, blockId);
+    return reader;
+  }
+
+  @Override
+  public void clearAll() {
+    assert(reader != null);
+    System.out.println("trying to clean spilled data.");
+    try {
+        reader.chunkInputStream.free();
+    } catch (IOException e) {
+        logger.debug(e.toString());
+    }
+  }
+}

--- a/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillWriter.java
+++ b/core/src/main/java/org/apache/spark/util/collection/unsafe/sort/UnsafeSorterStreamSpillWriter.java
@@ -25,7 +25,6 @@ public class UnsafeSorterStreamSpillWriter extends UnsafeSorterSpillWriter {
       ShuffleWriteMetrics writeMetrics,
       TaskMetrics taskMetrics) {
     super();
-    System.out.println("getting stream writer");
     final Tuple2<TempLocalBlockId, File> spilledFileInfo =
             blockManager.diskBlockManager().createTempLocalBlock();
     this.file = spilledFileInfo._2();
@@ -54,7 +53,6 @@ public class UnsafeSorterStreamSpillWriter extends UnsafeSorterSpillWriter {
   @Override
   public void clearAll() {
     assert(reader != null);
-    System.out.println("trying to clean spilled data.");
     try {
         reader.chunkInputStream.free();
     } catch (IOException e) {

--- a/core/src/main/scala/org/apache/spark/internal/config/package.scala
+++ b/core/src/main/scala/org/apache/spark/internal/config/package.scala
@@ -368,6 +368,12 @@ package object config {
       .booleanConf
       .createWithDefault(false)
 
+  val PMEM_PROPERTY_FILE =
+    ConfigBuilder("spark.memory.spill.pmem.config.file")
+      .doc("A config file used to config Intel PMem settings for memory extension.")
+      .stringConf
+      .createWithDefault("pmem.properties")
+
   val USAFE_EXTERNAL_SORTER_SPILL_WRITE_TYPE = ConfigBuilder("spark.unsafe.sort.spillwriter.type")
     .doc("The spill writer type for UnsafeExteranlSorter")
     .stringConf

--- a/core/src/main/scala/org/apache/spark/storage/PMemBlockObjectWriter.scala
+++ b/core/src/main/scala/org/apache/spark/storage/PMemBlockObjectWriter.scala
@@ -1,0 +1,295 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.io.{BufferedOutputStream, File, OutputStream}
+
+import com.intel.oap.common.storage.stream.{ChunkOutputStream, DataStore}
+
+import org.apache.spark.internal.Logging
+import org.apache.spark.memory.PMemManagerInitializer
+import org.apache.spark.serializer.{SerializationStream, SerializerInstance, SerializerManager}
+import org.apache.spark.shuffle.ShuffleWriteMetricsReporter
+import org.apache.spark.util.Utils
+
+/**
+ * A class for writing JVM objects directly to a file on disk. This class allows data to be appended
+ * to an existing block. For efficiency, it retains the underlying file channel across
+ * multiple commits. This channel is kept open until close() is called. In case of faults,
+ * callers should instead close with revertPartialWritesAndClose() to atomically revert the
+ * uncommitted partial writes.
+ *
+ * This class does not support concurrent writes. Also, once the writer has been opened it cannot be
+ * reopened again.
+ */
+private[spark] class PMemBlockObjectWriter(
+    file: File,
+    serializerManager: SerializerManager,
+    serializerInstance: SerializerInstance,
+    bufferSize: Int,
+    syncWrites: Boolean,
+    // These write metrics concurrently shared with other active DiskBlockObjectWriters who
+    // are themselves performing writes. All updates must be relative.
+    writeMetrics: ShuffleWriteMetricsReporter,
+    blockId: BlockId = null)
+  extends DiskBlockObjectWriter(file, serializerManager,
+    serializerInstance, bufferSize, syncWrites, writeMetrics, blockId)
+  with Logging {
+
+  /**
+   * Guards against close calls, e.g. from a wrapping stream.
+   * Call manualClose to close the stream that was extended by this trait.
+   * Commit uses this trait to close object streams without paying the
+   * cost of closing and opening the underlying file.
+   */
+  private trait ManualCloseOutputStream extends OutputStream {
+    abstract override def close(): Unit = {
+      flush()
+    }
+
+    def manualClose(): Unit = {
+      super.close()
+    }
+  }
+
+  // private var dataStore: DataStore = dataStore
+  /** The file channel, used for repositioning / truncating the file. */
+  // private var channel: FileChannel = null
+  private var mcs: ManualCloseOutputStream = null
+  private var bs: OutputStream = null
+  private var fos: ChunkOutputStream = null
+  private var ts: TimeTrackingOutputStream = null
+  private var objOut: SerializationStream = null
+  private var initialized = false
+  private var streamOpen = false
+  private var hasBeenClosed = false
+  private var dataStore: DataStore = null
+
+  def getFOS(): ChunkOutputStream = {
+   fos
+  }
+
+  // for tmp usage in UT
+  def getDataStore(): DataStore = {
+    dataStore
+  }
+
+  /**
+   * Cursors used to represent positions in the file.
+   *
+   * xxxxxxxxxx|----------|
+   *           ^          ^
+   *           |          |
+   *           |        reportedPosition
+   *         committedPosition
+   *
+   * reportedPosition: Position at the time of the last update to the write metrics.
+   * same as chunkoutputstream.position()
+   * committedPosition: Offset after last committed write.
+   * -----: Current writes to the underlying file.
+   * xxxxx: Committed contents of the file.
+   */
+  // private var committedPosition = file.length()
+  private var committedPosition = 0;
+  private var reportedPosition = committedPosition
+
+  /**
+   * Keep track of number of records written and also use this to periodically
+   * output bytes written since the latter is expensive to do for each record.
+   * And we reset it after every commitAndGet called.
+   */
+  private var numRecordsWritten = 0
+
+  private def initialize(): Unit = {
+    dataStore = new DataStore(PMemManagerInitializer.getPMemManager(),
+      PMemManagerInitializer.getProperties());
+    fos = ChunkOutputStream.getChunkOutputStreamInstance(file.toString, dataStore)
+    committedPosition = fos.position().toInt
+    reportedPosition = committedPosition
+    ts = new TimeTrackingOutputStream(writeMetrics, fos)
+    class ManualCloseBufferedOutputStream
+      extends BufferedOutputStream(ts, bufferSize) with ManualCloseOutputStream
+    mcs = new ManualCloseBufferedOutputStream
+  }
+
+  override def open(): PMemBlockObjectWriter = {
+    if (hasBeenClosed) {
+      throw new IllegalStateException("Writer already closed. Cannot be reopened.")
+    }
+    if (!initialized) {
+      initialize()
+      initialized = true
+    }
+
+    bs = serializerManager.wrapStream(blockId, mcs)
+    objOut = serializerInstance.serializeStream(bs)
+    streamOpen = true
+    this
+  }
+
+  /**
+   * Close and cleanup all resources.
+   * Should call after committing or reverting partial writes.
+   */
+  private def closeResources(): Unit = {
+    if (initialized) Utils.tryWithSafeFinally {
+      mcs.manualClose()
+    } {
+      mcs = null
+      bs = null
+      fos = null
+      ts = null
+      objOut = null
+      initialized = false
+      streamOpen = false
+      hasBeenClosed = true
+    }
+  }
+
+  /**
+   * Commits any remaining partial writes and closes resources.
+   */
+  override def close() {
+    if (initialized) {
+      Utils.tryWithSafeFinally {
+        commitAndGet()
+      } {
+        closeResources()
+      }
+    }
+  }
+
+  /**
+   * Flush the partial writes and commit them as a single atomic block.
+   * A commit may write additional bytes to frame the atomic block.
+   *
+   * @return file segment with previous offset and length committed on this call.
+   */
+  override def commitAndGet(): FileSegment = {
+    if (streamOpen) {
+      // NOTE: Because Kryo doesn't flush the underlying stream we explicitly flush both the
+      //       serializer stream and the lower level stream.
+      objOut.flush()
+      bs.flush()
+      objOut.close()
+      streamOpen = false
+
+      if (syncWrites) {
+        // Force outstanding writes to disk and track how long it takes
+        val start = System.nanoTime()
+        fos.getFD.sync()
+        writeMetrics.incWriteTime(System.nanoTime() - start)
+      }
+      val pos = fos.position().toInt
+      val previousCommitedPosition = committedPosition
+      val length = pos - committedPosition
+      committedPosition = pos
+      // In certain compression codecs, more bytes are written after streams are closed
+      writeMetrics.incBytesWritten(committedPosition - reportedPosition)
+      reportedPosition = committedPosition
+      numRecordsWritten = 0
+      new FileSegment(file, previousCommitedPosition, length)
+    } else {
+      new FileSegment(file, committedPosition, 0)
+    }
+  }
+
+
+  /**
+   * Reverts writes that haven't been committed yet. Callers should invoke this function
+   * when there are runtime exceptions. This method will not throw, though it may be
+   * unsuccessful in truncating written data.
+   *
+   * @return the file that this DiskBlockObjectWriter wrote to.
+   */
+  override def revertPartialWritesAndClose(): File = {
+    var cos: ChunkOutputStream = null
+    // Discard current writes. We do this by flushing the outstanding writes and then
+    // truncating the file to its initial position.
+    Utils.tryWithSafeFinally {
+      if (initialized) {
+        writeMetrics.decBytesWritten(reportedPosition - committedPosition)
+        writeMetrics.decRecordsWritten(numRecordsWritten)
+        streamOpen = false
+        closeResources()
+      }
+    } {
+      cos = ChunkOutputStream.getChunkOutputStreamInstance(file.toString, dataStore)
+      cos.truncate(committedPosition)
+    }
+    new File(file.toString)
+  }
+
+
+  /**
+    * Writes a key-value pair.
+    */
+  override def write(key: Any, value: Any): Unit = {
+    if (!streamOpen) {
+      open()
+    }
+
+    objOut.writeKey(key)
+    objOut.writeValue(value)
+    recordWritten()
+  }
+
+  override def write(b: Int): Unit = throw new UnsupportedOperationException()
+
+  override def write(kvBytes: Array[Byte], offs: Int, len: Int): Unit = {
+    if (!streamOpen) {
+      open()
+    }
+
+    bs.write(kvBytes, offs, len)
+  }
+
+  /**
+    * Notify the writer that a record worth of bytes has been written with OutputStream#write.
+    */
+  override def recordWritten(): Unit = {
+    numRecordsWritten += 1
+    writeMetrics.incRecordsWritten(1)
+
+    if (numRecordsWritten % 16384 == 0) {
+      updateBytesWritten()
+    }
+  }
+
+  // For testing
+  private[spark] override def flush(): Unit = {
+    objOut.flush()
+    bs.flush()
+  }
+
+  /**
+   * Report the number of bytes written in this writer's shuffle write metrics.
+   * Note that this is only valid before the underlying streams are closed.
+   */
+  private def updateBytesWritten() {
+    // val pos = channel.position()
+    // in high level, sometimes 16384 records written so this function called
+    // but the data is not actually wrote to PMem because writeBuffer isn't full
+    // and spill not finished
+    if (fos != null) {
+      val pos = fos.position().toInt
+      writeMetrics.incBytesWritten(pos - reportedPosition)
+      reportedPosition = pos
+    }
+  }
+}

--- a/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSpillWriterSuite.java
+++ b/core/src/test/java/org/apache/spark/util/collection/unsafe/sort/UnsafeExternalSorterSpillWriterSuite.java
@@ -37,6 +37,7 @@ public class UnsafeExternalSorterSpillWriterSuite extends UnsafeExternalSorterSu
             SpillWriterForUnsafeSorter pMemWriter = sorter.spillWithWriter(sortedIte, sortedIte.getNumRecords(),writeMetrics, true);
             UnsafeSorterIterator pMemReader = pMemWriter.getSpillReader();
             verifyIntIterator(pMemReader, 0, 100);
+            sorter.cleanupResources();
         }
     }
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
Stream API based implementation for memory spill is ported into new framework


### Why are the changes needed?
Support all PMem spill options for further adoption


### Does this PR introduce _any_ user-facing change?
Yes, path need define for "spark.memory.spill.pmem.config.file"


### How was this patch tested?
Q64 tested.
